### PR TITLE
Don't delete cooldown in Moonfire

### DIFF
--- a/Class/Druid/Spells/Moonfire.cpp
+++ b/Class/Druid/Spells/Moonfire.cpp
@@ -124,7 +124,6 @@ Moonfire::Moonfire(Druid* pchar, DruidSpells* druid_spells, const int spell_rank
 }
 
 Moonfire::~Moonfire() {
-    delete cooldown;
     delete instant_dmg;
     delete marker_buff;
 }


### PR DESCRIPTION
`cooldown` was being deleted in both `Moonfire` and `SpellPeriodic` and
was attempting to delete a non-new'd pointer and was failing.
Thus, remote the line in `Moonfire` since `SpellPeriodic` properly owns
this.