### PR TITLE
Added 5% spellcrit to Songflower Serenade

### DIFF
--- a/Spells/ExternalBuff.cpp
+++ b/Spells/ExternalBuff.cpp
@@ -58,6 +58,7 @@ void ExternalBuff::buff_effect_when_applied() {
         break;
     case ExternalBuffName::SongflowerSerenade:
         pchar->get_stats()->increase_melee_aura_crit(500);
+        pchar->get_stats()->increase_spell_crit(500);
         pchar->get_stats()->increase_ranged_crit(500);
         pchar->get_stats()->increase_agility(15);
         pchar->get_stats()->increase_strength(15);
@@ -221,6 +222,7 @@ void ExternalBuff::buff_effect_when_removed() {
         break;
     case ExternalBuffName::SongflowerSerenade:
         pchar->get_stats()->decrease_melee_aura_crit(500);
+        pchar->get_stats()->decrease_spell_crit(500);
         pchar->get_stats()->decrease_ranged_crit(500);
         pchar->get_stats()->decrease_agility(15);
         pchar->get_stats()->decrease_strength(15);


### PR DESCRIPTION
https://classic.wowhead.com/spell=15366/songflower-serenade Buff was missing the spell crit modifier.