### PR TITLE
added gear/set bonus for rogue pieces

### DIFF
--- a/Equipment/EquipmentDb/Gloves/leather.xml
+++ b/Equipment/EquipmentDb/Gloves/leather.xml
@@ -67,6 +67,20 @@
 		</source>
 	</item>
 
+	<item id="16712" phase="1">
+		<info name="Shadowcraft Gloves" type="LEATHER" slot="GLOVES" unique="no" req_lvl="54" item_lvl="59" quality="RARE" boe="yes" icon="Inv_gauntlets_24.png"/>
+		<stats>
+			<stat type="ARMOR" value="105"/>
+			<stat type="STRENGTH" value="9"/>
+			<stat type="AGILITY" value="14"/>
+			<stat type="STAMINA" value="9"/>
+			<stat type="SPIRIT" value="10"/>
+		</stats>
+		<source>
+			Blackrock Spire. Shadow Hunter Vosh'gajin.
+		</source>
+	</item>
+
 	<item id="13395" phase="1">
 		<info name="Skul's Fingerbone Claws" type="LEATHER" slot="GLOVES" unique="no" req_lvl="54" item_lvl="59" quality="RARE" boe="no" icon="Inv_gauntlets_27.png"/>
 		<stats>

--- a/Equipment/EquipmentDb/Gloves/plate.xml
+++ b/Equipment/EquipmentDb/Gloves/plate.xml
@@ -24,6 +24,19 @@
 		</source>
 	</item>
 
+	<item id="12639" phase="2">
+		<info name="Stronghold Gauntlets" type="PLATE" slot="GLOVES" unique="no" req_lvl="57" item_lvl="62" quality="UNCOMMON" boe="no" icon="Inv_gauntlets_30.png"/>
+		<stats>
+			<stat type="ARMOR" value="441"/>
+			<stat type="PARRY_CHANCE" value="0.01"/>
+			<stat type="CRIT_CHANCE" value="0.01"/>
+			<stat type="STAMINA" value="12"/>
+		</stats>
+		<source>
+			Blacksmith crafted.
+		</source>
+	</item>
+
 	<item id="18722" phase="1">
 		<info name="Death Grips" type="PLATE" slot="GLOVES" unique="no" req_lvl="57" item_lvl="62" quality="RARE" boe="no" icon="Inv_gauntlets_13.png"/>
 		<stats>

--- a/Equipment/EquipmentDb/Legs/leather.xml
+++ b/Equipment/EquipmentDb/Legs/leather.xml
@@ -39,6 +39,19 @@
 		</source>
 	</item>
 
+	<item id="16709" phase="1">
+		<info name="Shadowcraft Pants" type="LEATHER" slot="LEGS" unique="no" req_lvl="56" item_lvl="61" quality="RARE" boe="no" icon="Inv_pants_02.png"/>
+		<stats>
+			<stat type="ARMOR" value="150"/>
+			<stat type="STRENGTH" value="12"/>
+			<stat type="AGILITY" value="25"/>
+			<stat type="STAMINA" value="12"/>
+		</stats>
+		<source>
+			Baron Rivendare.
+		</source>
+	</item>
+
 	<item id="16822" phase="1">
 		<info name="Nightslayer Pants" type="LEATHER" slot="LEGS" unique="no" req_lvl="60" item_lvl="66" quality="EPIC" boe="no" icon="Inv_pants_06.png"/>
 		<class_restriction class="ROGUE"/>

--- a/Equipment/EquipmentDb/Wrists/leather.xml
+++ b/Equipment/EquipmentDb/Wrists/leather.xml
@@ -27,6 +27,18 @@
 		</source>
 	</wrist>
 
+	<wrist id="16710" phase="1">
+		<info name="Shadowcraft Bracers" type="LEATHER" slot="WRIST" unique="no" req_lvl="52" item_lvl="57" quality="RARE" boe="yes" icon="Inv_bracer_07.png"/>
+		<stats>
+			<stat type="ARMOR" value="71"/>
+			<stat type="AGILITY" value="15"/>
+			<stat type="STAMINA" value="7"/>
+		</stats>
+		<source>
+        Scholomance trash drop.
+		</source>
+	</wrist>
+
 	<wrist id="16825" phase="1">
 		<info name="Nightslayer Bracelets" type="LEATHER" slot="WRIST" unique="no" req_lvl="60" item_lvl="66" quality="EPIC" boe="yes" icon="Inv_bracer_02.png"/>
 		<class_restriction class="ROGUE"/>

--- a/Equipment/EquipmentDb/set_bonuses.xml
+++ b/Equipment/EquipmentDb/set_bonuses.xml
@@ -482,7 +482,7 @@
 		<bonus value="3">
 		(3) Set: Reduces the cooldown of your Vanish ability by 30 sec.
 		</bonus>
-		<bonus value="5" item_stat="AGILITY" stat_value="10">
+		<bonus value="5">
 		(5) Set: Increases your maximum Energy by 10.
 		</bonus>
 		<bonus value="8">

--- a/Equipment/EquipmentDb/set_bonuses.xml
+++ b/Equipment/EquipmentDb/set_bonuses.xml
@@ -99,6 +99,30 @@
 		</bonus>
 	</set>
 
+	<set name="Shadowcraft Armor">
+		<item_id value="16707"/>
+		<item_id value="16708"/>
+		<item_id value="16709"/>
+		<item_id value="16710"/>
+		<item_id value="16711"/>
+		<item_id value="16712"/>
+		<item_id value="16713"/>
+		<item_id value="16721"/>
+
+		<bonus value="2">
+		(2) Set: +200 Armor.
+		</bonus>
+		<bonus value="4" item_stat="ATTACK_POWER" stat_value="40">
+		(4) Set: +40 Attack Power.
+		</bonus>
+		<bonus value="6" item_stat="AGILITY" stat_value="30">
+		(6) Set: Chance on melee attack to restore 35 energy.
+		</bonus>
+		<bonus value="8">
+		(8) Set: +8 All Resistances.
+		</bonus>
+	</set>
+
 	<set name="Dal'Rend's Arms">
 		<item_id value="12940"/>
 		<item_id value="12939"/>
@@ -458,7 +482,7 @@
 		<bonus value="3">
 		(3) Set: Reduces the cooldown of your Vanish ability by 30 sec.
 		</bonus>
-		<bonus value="5">
+		<bonus value="5" item_stat="AGILITY" stat_value="10">
 		(5) Set: Increases your maximum Energy by 10.
 		</bonus>
 		<bonus value="8">
@@ -763,7 +787,7 @@
 		(8) Set: Reduces the mana cost of your Multi-Shot and Aimed Shot by 20.
 		</bonus>
 	</set>
-	
+
 	<set name="Magister's Regalia">
 		<item_id value="16685"/>
 		<item_id value="16683"/>

--- a/QML/Assets/items/Inv_gauntlets_24.png
+++ b/QML/Assets/items/Inv_gauntlets_24.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7d7bc31c167a4096555e3fe9a5ebdbb64f1e85a3dabca50ba71d3d3847673c8
+size 9235

--- a/qml.qrc
+++ b/qml.qrc
@@ -130,6 +130,7 @@
         <file>QML/Assets/items/Inv_bracer_04.png</file>
         <file>QML/Assets/items/Inv_chest_chain_15.png</file>
         <file>QML/Assets/items/Inv_gauntlets_31.png</file>
+        <file>QML/Assets/items/Inv_gauntlets_24.png</file>
         <file>QML/Assets/items/Inv_misc_cape_naxxramas_03.png</file>
         <file>QML/Assets/items/Inv_jewelry_necklace_28naxxramas.png</file>
         <file>QML/Assets/items/Inv_shoulder_35.png</file>


### PR DESCRIPTION
Added missing shadowcraft pieces, icons, and implemented set bonus for shadowcraft and nightslayer.

I'm not sure if it's even possible to implement the special set effects as described so instead I implemented their calculated agility weight from https://shadowpanther.net/armor-sets.htm which I imagine is better than nothing.