### PR TITLE
Add a seal fate dagger rogue rotation

### DIFF
--- a/Rotation/Rotations/Rogue/SealFateDagger.xml
+++ b/Rotation/Rotations/Rogue/SealFateDagger.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<rotation class="Rogue" name="Seal Fate Dagger" attack_mode="melee">
+	<description>
+	A rotation for Seal Fate dagger rogues.
+	</description>
+
+	<cast_if name="Slice and Dice">
+		buff_duration "Slice and Dice" less 3
+	</cast_if>
+
+	<cast_if name="Backstab">
+		variable "combo_points" less 4
+	</cast_if>
+
+	<cast_if name="Eviscerate">
+		variable "combo_points" geq 4
+		and buff_duration "Slice and Dice" greater 8
+	</cast_if>
+
+	<cast_if name="Kiss of the Spider">
+		 variable "time_remaining_execute" greater 120
+		 or variable "time_remaining_execute" less 0
+	</cast_if>
+
+	<cast_if name="Jom Gabbar">
+		variable "time_remaining_execute" greater 120
+		or variable "time_remaining_execute" less 0
+	</cast_if>
+
+	<cast_if name="Badge of the Swarmguard">
+		variable "time_remaining_execute" greater 120
+		or variable "time_remaining_execute" less 0
+	</cast_if>
+
+	<cast_if name="Slayer's Crest">
+		variable "time_remaining_execute" greater 120
+		or variable "time_remaining_execute" less 0
+	</cast_if>
+
+	<cast_if name="Earthstrike">
+		variable "time_remaining_execute" greater 120
+		or variable "time_remaining_execute" less 0
+	</cast_if>
+
+	<cast_if name="Zandalarian Hero Medallion">
+		variable "time_remaining_execute" greater 120
+		or variable "time_remaining_execute" less 0
+	</cast_if>
+
+	<cast_if name="Blood Fury">
+		variable "time_remaining_execute" less 0
+		and resource "Energy" less 50
+		or variable "time_remaining_execute" greater 120
+	</cast_if>
+
+	<cast_if name="Berserking">
+		variable "time_remaining_execute" less 0
+		and resource "Energy" less 50
+		or variable "time_remaining_execute" greater 180
+	</cast_if>
+</rotation>

--- a/Rotation/Rotations/rotation_paths.xml
+++ b/Rotation/Rotations/rotation_paths.xml
@@ -8,6 +8,7 @@
 
 	<file path="Rotations/Rogue/Combat.xml"/>
 	<file path="Rotations/Rogue/CombatDagger.xml"/>
+	<file path="Rotations/Rogue/SealFateDagger.xml"/>
 	<file path="Rotations/Rogue/Hemorrhage.xml"/>
 
 	<file path="Rotations/Hunter/Marksmanship.xml"/>


### PR DESCRIPTION
This adds a pve rotation for the 3X/xx/5 variation of rogue builds that utilize seal fate.