### PR TITLE
Fix basic stats for all characters

### DIFF
--- a/Character/Character.cpp
+++ b/Character/Character.cpp
@@ -84,6 +84,8 @@ void Character::set_race(Race* race) {
     spells->deactivate_racials();
     this->race = race;
     spells->activate_racials();
+
+    set_special_statistics();
 }
 
 void Character::change_target_creature_type(const QString& creature_type) {
@@ -520,4 +522,53 @@ void Character::prepare_set_of_combat_iterations() {
     spells->prepare_set_of_combat_iterations();
     enabled_buffs->prepare_set_of_combat_iterations();
     enabled_procs->prepare_set_of_combat_iterations();
+}
+
+void Character::set_special_statistics()
+{
+    // Reset special statistics cases
+    if (is_orc_warlock) cstats->increase_stamina(1);
+    cstats->decrease_intellect(intellect_offset);
+    cstats->decrease_spirit(spirit_offset);
+    is_orc_warlock = false;
+    intellect_offset = 0;
+    spirit_offset = 0;
+
+    // Gnome special case
+    if (race->get_race_int() == Races::Gnome) {
+        if (class_name == "Mage") {
+            intellect_offset = 3;
+            cstats->increase_intellect(intellect_offset);
+        }
+        else if (class_name == "Warlock") {
+            intellect_offset = 4;
+            cstats->increase_intellect(intellect_offset);
+        }
+    }
+
+    // Human special case
+    if (race->get_race_int() == Races::Human) {
+        if (class_name == "Mage") {
+            spirit_offset = 4;
+            cstats->increase_spirit(spirit_offset);
+        }
+        else if (class_name == "Paladin") {
+            spirit_offset = 1;
+            cstats->increase_spirit(spirit_offset);
+        }
+        else if (class_name == "Priest") {
+            spirit_offset = 4;
+            cstats->increase_spirit(spirit_offset);
+        }
+        else if (class_name == "Warlock") {
+            spirit_offset = 3;
+            cstats->increase_spirit(spirit_offset);
+        }
+    }
+
+    // Orc warlock special case
+    if (race->get_race_int() == Races::Orc && class_name == "Warlock") {
+        is_orc_warlock = true;
+        cstats->decrease_stamina(1);
+    }
 }

--- a/Character/Character.h
+++ b/Character/Character.h
@@ -59,14 +59,11 @@ public:
     void set_race(Race* race);
     bool race_available(Race*) const;
 
+    void set_special_statistics();
+
     virtual int get_highest_possible_armor_type() const = 0;
     virtual QVector<int> get_weapon_proficiencies_for_slot(const int) const = 0;
 
-    virtual unsigned get_strength_modifier() const = 0;
-    virtual unsigned get_agility_modifier() const = 0;
-    virtual unsigned get_stamina_modifier() const = 0;
-    virtual unsigned get_intellect_modifier() const = 0;
-    virtual unsigned get_spirit_modifier() const = 0;
     virtual double get_agi_needed_for_one_percent_phys_crit() const = 0;
     virtual double get_int_needed_for_one_percent_spell_crit() const = 0;
     virtual unsigned get_melee_ap_per_strength() const = 0;
@@ -193,4 +190,11 @@ protected:
 
     virtual void reset_resource();
     virtual void reset_class_specific() = 0;
+
+private:
+    // Special statistics cases
+    bool is_orc_warlock = false;
+    uint intellect_offset = 0;
+    uint spirit_offset = 0;
+
 };

--- a/Character/CharacterStats.cpp
+++ b/Character/CharacterStats.cpp
@@ -19,12 +19,6 @@ CharacterStats::CharacterStats(Character* pchar, EquipmentDb* equipment_db) :
     this->aura_effects = new Stats();
     this->base_stats = new Stats();
 
-    increase_strength(pchar->get_strength_modifier());
-    increase_agility(pchar->get_agility_modifier());
-    increase_stamina(pchar->get_stamina_modifier());
-    increase_intellect(pchar->get_intellect_modifier());
-    increase_spirit(pchar->get_spirit_modifier());
-
     this->crit_bonuses_per_weapon_type.insert(WeaponTypes::AXE, 0);
     this->crit_bonuses_per_weapon_type.insert(WeaponTypes::TWOHAND_AXE, 0);
     this->crit_bonuses_per_weapon_type.insert(WeaponTypes::DAGGER, 0);

--- a/Character/Race/Races/Gnome.cpp
+++ b/Character/Race/Races/Gnome.cpp
@@ -22,7 +22,7 @@ unsigned Gnome::get_base_stamina() const {
 }
 
 unsigned Gnome::get_base_intellect() const {
-    return 23;
+    return 25;
 }
 
 unsigned Gnome::get_base_spirit() const {

--- a/Character/Race/Races/Human.cpp
+++ b/Character/Race/Races/Human.cpp
@@ -26,7 +26,7 @@ unsigned Human::get_base_intellect() const {
 }
 
 unsigned Human::get_base_spirit() const {
-    return 20;
+    return 22;
 }
 
 double Human::get_int_multiplier() const {

--- a/Class/Druid/Druid.cpp
+++ b/Class/Druid/Druid.cpp
@@ -36,8 +36,9 @@ Druid::Druid(Race* race_, EquipmentDb* equipment_db, SimSettings* sim_settings_,
     set_clvl(60);
     this->cstats = new CharacterStats(this, equipment_db);
 
-    cstats->increase_agility(40);
+    // Druid base stats
     cstats->increase_strength(45);
+    cstats->increase_agility(40);
     cstats->increase_stamina(50);
     cstats->increase_intellect(80);
     cstats->increase_spirit(90);
@@ -66,26 +67,6 @@ Druid::~Druid()
     delete energy;
     delete rage;
     delete druid_spells;
-}
-
-unsigned Druid::get_strength_modifier() const {
-    return 1;
-}
-
-unsigned Druid::get_agility_modifier() const {
-    return 0;
-}
-
-unsigned Druid::get_stamina_modifier() const {
-    return 0;
-}
-
-unsigned Druid::get_intellect_modifier() const {
-    return 2;
-}
-
-unsigned Druid::get_spirit_modifier() const {
-    return 2;
 }
 
 double Druid::get_mp5_from_spirit() const {

--- a/Class/Druid/Druid.h
+++ b/Class/Druid/Druid.h
@@ -19,11 +19,6 @@ public:
     Druid(Race* race, EquipmentDb* equipment_db, SimSettings* sim_settings, RaidControl* raid_control, const int party = -1, const int member = -1);
     ~Druid() override;
 
-    unsigned get_strength_modifier() const override;
-    unsigned get_agility_modifier() const override;
-    unsigned get_stamina_modifier() const override;
-    unsigned get_intellect_modifier() const override;
-    unsigned get_spirit_modifier() const override;
     double get_agi_needed_for_one_percent_phys_crit() const override;
     double get_int_needed_for_one_percent_spell_crit() const override;
     double get_mp5_from_spirit() const override;

--- a/Class/Hunter/Hunter.cpp
+++ b/Class/Hunter/Hunter.cpp
@@ -29,8 +29,9 @@ Hunter::Hunter(Race* race_, EquipmentDb* equipment_db, SimSettings* sim_settings
     set_clvl(60);
     this->cstats = new CharacterStats(this, equipment_db);
 
-    cstats->increase_agility(100);
+    // Hunter base stats
     cstats->increase_strength(35);
+    cstats->increase_agility(105);
     cstats->increase_stamina(70);
     cstats->increase_intellect(45);
     cstats->increase_spirit(50);
@@ -65,26 +66,6 @@ Hunter::~Hunter()
     delete cstats;
     delete hunter_spells;
     delete mana;
-}
-
-unsigned Hunter::get_strength_modifier() const {
-    return 0;
-}
-
-unsigned Hunter::get_agility_modifier() const {
-    return 3;
-}
-
-unsigned Hunter::get_stamina_modifier() const {
-    return 1;
-}
-
-unsigned Hunter::get_intellect_modifier() const {
-    return 0;
-}
-
-unsigned Hunter::get_spirit_modifier() const {
-    return 1;
 }
 
 double Hunter::get_mp5_from_spirit() const {

--- a/Class/Hunter/Hunter.h
+++ b/Class/Hunter/Hunter.h
@@ -10,11 +10,6 @@ public:
     Hunter(Race* race, EquipmentDb* equipment_db, SimSettings* sim_settings, RaidControl* raid_control, const int party = -1, const int member = -1);
     ~Hunter() override;
 
-    unsigned get_strength_modifier() const override;
-    unsigned get_agility_modifier() const override;
-    unsigned get_stamina_modifier() const override;
-    unsigned get_intellect_modifier() const override;
-    unsigned get_spirit_modifier() const override;
     double get_agi_needed_for_one_percent_phys_crit() const override;
     double get_int_needed_for_one_percent_spell_crit() const override;
     double get_mp5_from_spirit() const override;

--- a/Class/Mage/Mage.cpp
+++ b/Class/Mage/Mage.cpp
@@ -9,6 +9,8 @@
 #include "Equipment.h"
 #include "Fire.h"
 #include "Frost.h"
+#include "Gnome.h"
+#include "Human.h"
 #include "MageEnchants.h"
 #include "MageSpells.h"
 #include "Mana.h"
@@ -27,8 +29,9 @@ Mage::Mage(Race* race, EquipmentDb* equipment_db, SimSettings* sim_settings, Rai
     set_clvl(60);
     this->cstats = new CharacterStats(this, equipment_db);
 
+    // Mage base stats
+    cstats->increase_strength(10);
     cstats->increase_agility(15);
-    cstats->increase_strength(5);
     cstats->increase_stamina(25);
     cstats->increase_intellect(105);
     cstats->increase_spirit(100);
@@ -55,26 +58,6 @@ Mage::~Mage()
     delete cstats;
     delete mage_spells;
     delete mana;
-}
-
-unsigned Mage::get_strength_modifier() const {
-    return 0;
-}
-
-unsigned Mage::get_agility_modifier() const {
-    return 0;
-}
-
-unsigned Mage::get_stamina_modifier() const {
-    return 0;
-}
-
-unsigned Mage::get_intellect_modifier() const {
-    return 3;
-}
-
-unsigned Mage::get_spirit_modifier() const {
-    return 2;
 }
 
 double Mage::get_mp5_from_spirit() const {

--- a/Class/Mage/Mage.h
+++ b/Class/Mage/Mage.h
@@ -10,11 +10,6 @@ public:
     Mage(Race* race, EquipmentDb* equipment_db, SimSettings* sim_settings, RaidControl* raid_control, const int party = -1, const int member = -1);
     ~Mage() override;
 
-    unsigned get_strength_modifier() const override;
-    unsigned get_agility_modifier() const override;
-    unsigned get_stamina_modifier() const override;
-    unsigned get_intellect_modifier() const override;
-    unsigned get_spirit_modifier() const override;
     double get_agi_needed_for_one_percent_phys_crit() const override;
     double get_int_needed_for_one_percent_spell_crit() const override;
     double get_mp5_from_spirit() const override;

--- a/Class/Paladin/Paladin.cpp
+++ b/Class/Paladin/Paladin.cpp
@@ -25,11 +25,12 @@ Paladin::Paladin(Race* race_, EquipmentDb* equipment_db, SimSettings* sim_settin
     set_clvl(60);
     this->cstats = new CharacterStats(this, equipment_db);
 
-    cstats->increase_agility(20);
-    cstats->increase_strength(15);
-    cstats->increase_stamina(30);
-    cstats->increase_intellect(100);
-    cstats->increase_spirit(105);
+    // Paladin base stats
+    cstats->increase_strength(85);
+    cstats->increase_agility(45);
+    cstats->increase_stamina(80);
+    cstats->increase_intellect(50);
+    cstats->increase_spirit(55);
     cstats->increase_melee_ap(160);
 
     this->paladin_spells = new PaladinSpells(this);
@@ -55,26 +56,6 @@ Paladin::~Paladin()
     delete paladin_spells;
     delete mana;
     delete vengeance;
-}
-
-unsigned Paladin::get_strength_modifier() const {
-    return 2;
-}
-
-unsigned Paladin::get_agility_modifier() const {
-    return 0;
-}
-
-unsigned Paladin::get_stamina_modifier() const {
-    return 2;
-}
-
-unsigned Paladin::get_intellect_modifier() const {
-    return 0;
-}
-
-unsigned Paladin::get_spirit_modifier() const {
-    return 1;
 }
 
 double Paladin::get_mp5_from_spirit() const {

--- a/Class/Paladin/Paladin.h
+++ b/Class/Paladin/Paladin.h
@@ -12,11 +12,6 @@ public:
     Paladin(Race* race, EquipmentDb* equipment_db, SimSettings* sim_settings, RaidControl* raid_control, const int party = -1, const int member = -1);
     ~Paladin() override;
 
-    unsigned get_strength_modifier() const override;
-    unsigned get_agility_modifier() const override;
-    unsigned get_stamina_modifier() const override;
-    unsigned get_intellect_modifier() const override;
-    unsigned get_spirit_modifier() const override;
     double get_agi_needed_for_one_percent_phys_crit() const override;
     double get_int_needed_for_one_percent_spell_crit() const override;
     double get_mp5_from_spirit() const override;

--- a/Class/Priest/Priest.cpp
+++ b/Class/Priest/Priest.cpp
@@ -21,8 +21,9 @@ Priest::Priest(Race* race_, EquipmentDb* equipment_db, SimSettings* sim_settings
     set_clvl(60);
     this->cstats = new CharacterStats(this, equipment_db);
 
-    cstats->increase_agility(20);
+    // Priest base stats
     cstats->increase_strength(15);
+    cstats->increase_agility(20);
     cstats->increase_stamina(30);
     cstats->increase_intellect(100);
     cstats->increase_spirit(105);
@@ -46,26 +47,6 @@ Priest::~Priest()
     delete cstats;
     delete priest_spells;
     delete mana;
-}
-
-unsigned Priest::get_strength_modifier() const {
-    return 0;
-}
-
-unsigned Priest::get_agility_modifier() const {
-    return 0;
-}
-
-unsigned Priest::get_stamina_modifier() const {
-    return 0;
-}
-
-unsigned Priest::get_intellect_modifier() const {
-    return 2;
-}
-
-unsigned Priest::get_spirit_modifier() const {
-    return 3;
 }
 
 double Priest::get_mp5_from_spirit() const {

--- a/Class/Priest/Priest.h
+++ b/Class/Priest/Priest.h
@@ -10,11 +10,6 @@ public:
     Priest(Race* race, EquipmentDb* equipment_db, SimSettings* sim_settings, RaidControl* raid_control, const int party = -1, const int member = -1);
     ~Priest() override;
 
-    unsigned get_strength_modifier() const override;
-    unsigned get_agility_modifier() const override;
-    unsigned get_stamina_modifier() const override;
-    unsigned get_intellect_modifier() const override;
-    unsigned get_spirit_modifier() const override;
     double get_agi_needed_for_one_percent_phys_crit() const override;
     double get_int_needed_for_one_percent_spell_crit() const override;
     double get_mp5_from_spirit() const override;

--- a/Class/Rogue/Rogue.cpp
+++ b/Class/Rogue/Rogue.cpp
@@ -38,9 +38,10 @@ Rogue::Rogue(Race* race_, EquipmentDb* equipment_db, SimSettings* sim_settings_,
     set_clvl(60);
     this->cstats = new CharacterStats(this, equipment_db);
 
-    cstats->increase_agility(110);
+    // Rogue base stats
     cstats->increase_strength(60);
-    cstats->increase_stamina(60);
+    cstats->increase_agility(110);
+    cstats->increase_stamina(55);
     cstats->increase_intellect(15);
     cstats->increase_spirit(30);
     cstats->increase_melee_ap(100);
@@ -79,26 +80,6 @@ Rogue::~Rogue()
     delete ruthlessness;
     delete seal_fate;
     delete sword_spec;
-}
-
-unsigned Rogue::get_strength_modifier() const {
-    return 1;
-}
-
-unsigned Rogue::get_agility_modifier() const {
-    return 3;
-}
-
-unsigned Rogue::get_stamina_modifier() const {
-    return 1;
-}
-
-unsigned Rogue::get_intellect_modifier() const {
-    return 0;
-}
-
-unsigned Rogue::get_spirit_modifier() const {
-    return 0;
 }
 
 double Rogue::get_agi_needed_for_one_percent_phys_crit() const {

--- a/Class/Rogue/Rogue.h
+++ b/Class/Rogue/Rogue.h
@@ -16,11 +16,6 @@ public:
     Rogue(Race* race, EquipmentDb* equipment_db, SimSettings* sim_settings, RaidControl* raid_control, const int party = -1, const int member = -1);
     ~Rogue() override;
 
-    unsigned get_strength_modifier() const override;
-    unsigned get_agility_modifier() const override;
-    unsigned get_stamina_modifier() const override;
-    unsigned get_intellect_modifier() const override;
-    unsigned get_spirit_modifier() const override;
     double get_agi_needed_for_one_percent_phys_crit() const override;
     double get_int_needed_for_one_percent_spell_crit() const override;
     double global_cooldown() const override;

--- a/Class/Shaman/Shaman.cpp
+++ b/Class/Shaman/Shaman.cpp
@@ -26,10 +26,11 @@ Shaman::Shaman(Race* race_, EquipmentDb* equipment_db, SimSettings* sim_settings
     set_clvl(60);
     this->cstats = new CharacterStats(this, equipment_db);
 
-    cstats->increase_agility(30);
-    cstats->increase_strength(70);
+    // Shaman base stats
+    cstats->increase_strength(65);
+    cstats->increase_agility(35);
     cstats->increase_stamina(75);
-    cstats->increase_intellect(65);
+    cstats->increase_intellect(70);
     cstats->increase_spirit(80);
     cstats->increase_melee_ap(160);
 
@@ -55,26 +56,6 @@ Shaman::~Shaman()
     delete cstats;
     delete shaman_spells;
     delete mana;
-}
-
-unsigned Shaman::get_strength_modifier() const {
-    return 1;
-}
-
-unsigned Shaman::get_agility_modifier() const {
-    return 0;
-}
-
-unsigned Shaman::get_stamina_modifier() const {
-    return 1;
-}
-
-unsigned Shaman::get_intellect_modifier() const {
-    return 1;
-}
-
-unsigned Shaman::get_spirit_modifier() const {
-    return 2;
 }
 
 double Shaman::get_mp5_from_spirit() const {

--- a/Class/Shaman/Shaman.h
+++ b/Class/Shaman/Shaman.h
@@ -10,11 +10,6 @@ public:
     Shaman(Race* race, EquipmentDb* equipment_db, SimSettings* sim_settings, RaidControl* raid_control, const int party = -1, const int member = -1);
     ~Shaman() override;
 
-    unsigned get_strength_modifier() const override;
-    unsigned get_agility_modifier() const override;
-    unsigned get_stamina_modifier() const override;
-    unsigned get_intellect_modifier() const override;
-    unsigned get_spirit_modifier() const override;
     double get_agi_needed_for_one_percent_phys_crit() const override;
     double get_int_needed_for_one_percent_spell_crit() const override;
     double get_mp5_from_spirit() const override;

--- a/Class/Warlock/Warlock.cpp
+++ b/Class/Warlock/Warlock.cpp
@@ -20,11 +20,12 @@ Warlock::Warlock(Race* race_, EquipmentDb* equipment_db, SimSettings* sim_settin
     set_clvl(60);
     this->cstats = new CharacterStats(this, equipment_db);
 
+    // Warlock base stats
     cstats->increase_agility(30);
     cstats->increase_strength(25);
     cstats->increase_stamina(45);
-    cstats->increase_intellect(95);
-    cstats->increase_spirit(100);
+    cstats->increase_intellect(90);
+    cstats->increase_spirit(95);
 
     this->warlock_spells = new WarlockSpells(this);
     this->spells = warlock_spells;
@@ -45,26 +46,6 @@ Warlock::~Warlock()
     delete cstats;
     delete warlock_spells;
     delete mana;
-}
-
-unsigned Warlock::get_strength_modifier() const {
-    return 0;
-}
-
-unsigned Warlock::get_agility_modifier() const {
-    return 0;
-}
-
-unsigned Warlock::get_stamina_modifier() const {
-    return 1;
-}
-
-unsigned Warlock::get_intellect_modifier() const {
-    return 2;
-}
-
-unsigned Warlock::get_spirit_modifier() const {
-    return 2;
 }
 
 double Warlock::get_mp5_from_spirit() const {

--- a/Class/Warlock/Warlock.h
+++ b/Class/Warlock/Warlock.h
@@ -10,11 +10,6 @@ public:
     Warlock(Race* race, EquipmentDb* equipment_db, SimSettings* sim_settings, RaidControl* raid_control, const int party = -1, const int member = -1);
     ~Warlock() override;
 
-    unsigned get_strength_modifier() const override;
-    unsigned get_agility_modifier() const override;
-    unsigned get_stamina_modifier() const override;
-    unsigned get_intellect_modifier() const override;
-    unsigned get_spirit_modifier() const override;
     double get_agi_needed_for_one_percent_phys_crit() const override;
     double get_int_needed_for_one_percent_spell_crit() const override;
     double get_mp5_from_spirit() const override;

--- a/Class/Warrior/Warrior.cpp
+++ b/Class/Warrior/Warrior.cpp
@@ -37,11 +37,12 @@ Warrior::Warrior(Race* race, EquipmentDb* equipment_db, SimSettings* sim_setting
     set_clvl(60);
     this->cstats = new CharacterStats(this, equipment_db);
 
+    // Warrior base stats
+    cstats->increase_strength(100);
     cstats->increase_agility(60);
+    cstats->increase_stamina(90);
     cstats->increase_intellect(10);
     cstats->increase_spirit(25);
-    cstats->increase_stamina(90);
-    cstats->increase_strength(100);
     cstats->increase_melee_ap(160);
     cstats->increase_melee_base_crit(200);
 
@@ -68,26 +69,6 @@ Warrior::~Warrior() {
     delete cstats;
     delete warr_spells;
     delete rage;
-}
-
-unsigned Warrior::get_strength_modifier() const {
-    return 3;
-}
-
-unsigned Warrior::get_agility_modifier() const {
-    return 0;
-}
-
-unsigned Warrior::get_stamina_modifier() const {
-    return 2;
-}
-
-unsigned Warrior::get_intellect_modifier() const {
-    return 0;
-}
-
-unsigned Warrior::get_spirit_modifier() const {
-    return 0;
 }
 
 double Warrior::get_agi_needed_for_one_percent_phys_crit() const {

--- a/Class/Warrior/Warrior.h
+++ b/Class/Warrior/Warrior.h
@@ -16,11 +16,6 @@ public:
     Warrior(Race* race, EquipmentDb* equipment_db, SimSettings* sim_settings, RaidControl* raid_control, const int party = -1, const int member = -1);
     ~Warrior() override;
 
-    unsigned get_strength_modifier() const override;
-    unsigned get_agility_modifier() const override;
-    unsigned get_stamina_modifier() const override;
-    unsigned get_intellect_modifier() const override;
-    unsigned get_spirit_modifier() const override;
     double get_agi_needed_for_one_percent_phys_crit() const override;
     double get_int_needed_for_one_percent_spell_crit() const override;
     unsigned get_melee_ap_per_strength() const override;

--- a/GUI/GUIControl.cpp
+++ b/GUI/GUIControl.cpp
@@ -219,6 +219,7 @@ GUIControl::~GUIControl() {
 void GUIControl::set_character(Character* pchar) {
     sim_settings->use_ruleset(Ruleset::Standard, current_char);
     current_char = pchar;
+    current_char->set_special_statistics();
     raid_control = raid_controls[current_char->class_name];
     item_type_filter_model->set_character(current_char);
     item_model->set_character(current_char);


### PR DESCRIPTION
Fix #42 and part 4 of #102 

Values are taken from https://classicwow.live/guides/46/basic-stats-sheet

I removed virtual methods from Character class since they are redundant with increase_xxx methods from CharacterStats.

7 special cases had to be added because there is no set of parameters to obtain all the basic statistics specified in the link above.