### PR TITLE
Add Darkmoon Card: Maelstrom and Sanctified Orb

### DIFF
--- a/Class/Common/Buffs/SanctifiedOrb.cpp
+++ b/Class/Common/Buffs/SanctifiedOrb.cpp
@@ -1,0 +1,18 @@
+#include "SanctifiedOrb.h"
+
+#include "Character.h"
+#include "CharacterStats.h"
+
+SanctifiedOrb::SanctifiedOrb(Character* pchar):
+    SelfBuff(pchar, "Sanctified Orb", "Assets/items/Inv_misc_gem_pearl_04.png", 25, 0)
+{}
+
+void SanctifiedOrb::buff_effect_when_applied() {
+    pchar->get_stats()->increase_melee_aura_crit(300);
+    pchar->get_stats()->increase_spell_crit(300);
+}
+
+void SanctifiedOrb::buff_effect_when_removed() {
+    pchar->get_stats()->decrease_melee_aura_crit(300);
+    pchar->get_stats()->decrease_spell_crit(300);
+}

--- a/Class/Common/Buffs/SanctifiedOrb.h
+++ b/Class/Common/Buffs/SanctifiedOrb.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "SelfBuff.h"
+
+class SanctifiedOrb: public SelfBuff {
+public:
+    SanctifiedOrb(Character* pchar);
+
+private:
+    void buff_effect_when_applied() override;
+    void buff_effect_when_removed() override;
+};

--- a/ClassicSim.pro
+++ b/ClassicSim.pro
@@ -15,6 +15,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 SOURCES += main.cpp \
     Class/Common/Buffs/NoEffectSelfBuff.cpp \
     Class/Common/Buffs/NoEffectUniqueDebuff.cpp \
+    Class/Common/Buffs/SanctifiedOrb.cpp \
     Class/Common/Buffs/SuppressCastBuff.cpp \
     Class/Common/Buffs/ZandalarianHeroCharm.cpp \
     Class/Common/Procs/ResourceGainProc.cpp \
@@ -494,6 +495,7 @@ SOURCES += main.cpp \
 HEADERS += \
     Class/Common/Buffs/NoEffectSelfBuff.h \
     Class/Common/Buffs/NoEffectUniqueDebuff.h \
+    Class/Common/Buffs/SanctifiedOrb.h \
     Class/Common/Buffs/SuppressCastBuff.h \
     Class/Common/Buffs/ZandalarianHeroCharm.h \
     Class/Common/Procs/ResourceGainProc.h \

--- a/Equipment/EquipmentDb/Misc/trinkets.xml
+++ b/Equipment/EquipmentDb/Misc/trinkets.xml
@@ -283,10 +283,11 @@
 		</source>
 	</item>
 
-	<item id="20130" phase="4">
+	<item id="20130" phase="3">
 		<info name="Diamond Flask" type="TRINKET" slot="TRINKET" unique="no" req_lvl="50" item_lvl="52" quality="RARE" boe="no" icon="Inv_drink_01.png"/>
 		<mutex item_id="20251"/>
 		<mutex item_id="20517"/>
+		<class_restriction class="WARRIOR"/>
 		<stats/>
 		<uses>
 			<use name="GENERIC_STAT_BUFF" type="STRENGTH" value="75" duration="60" cooldown="360"/>
@@ -302,7 +303,7 @@
 		</flavour_text>
 	</item>
 
-	<item id="19991" phase="1">
+	<item id="19991" phase="3">
 		<info name="Devilsaur Eye" type="TRINKET" slot="TRINKET" unique="yes" req_lvl="50" item_lvl="52" quality="RARE" boe="no" icon="Inv_misc_eye_01.png"/>
 		<mutex item_id="19992"/>
 		<mutex item_id="20083"/>
@@ -318,6 +319,22 @@
 		<special_equip_effect>
 			Use: Increases your attack power by 150 and your chance to hit by 2%. Effect lasts for 20 sec. (cooldown 2 min)
 		</special_equip_effect>
+	</item>
+
+	<item id="20512" phase="3">
+		<info name="Sanctified Orb" type="TRINKET" slot="TRINKET" unique="no" req_lvl="50" item_lvl="52" quality="RARE" boe="no" icon="Inv_misc_gem_pearl_04.png"/>
+		<mutex item_id="20504"/>
+		<mutex item_id="20505"/>
+		<class_restriction class="PALADIN"/>
+		<uses>
+            <use name="SANCTIFIED_ORB"/>
+		</uses>
+		<special_equip_effect>
+			Use: Increases your critical strike chance with spells and melee attacks by 3%.  Lasts 25 sec. (3 Min Cooldown)
+		</special_equip_effect>
+		<source>
+			Quest reward. Requires Sunken Temple.
+		</source>
 	</item>
 
 	<item id="19930" phase="4">

--- a/Equipment/EquipmentDb/Misc/trinkets.xml
+++ b/Equipment/EquipmentDb/Misc/trinkets.xml
@@ -270,6 +270,19 @@
 		</source>
 	</item>
 
+	<item id="19289" phase="3">
+		<info name="Darkmoon Card: Maelstrom" type="TRINKET" slot="TRINKET" unique="yes" req_lvl="60" item_lvl="66" quality="EPIC" boe="no" icon="Inv_misc_ticket_tarot_maelstrom_01.png"/>
+		<proc>
+			<spell name="NATURE_ATTACK" min="200" max="300" instant="yes" rate="0.02" internal_cd="0" spell_dmg_coefficient="0.0"/>
+		</proc>
+		<special_equip_effect>
+			Equip: Chance to strike your melee target with lightning for 200 to 300 Nature damage.
+		</special_equip_effect>
+		<source>
+			Reward from Darkmoon Elementals Deck.
+		</source>
+	</item>
+
 	<item id="20130" phase="4">
 		<info name="Diamond Flask" type="TRINKET" slot="TRINKET" unique="no" req_lvl="50" item_lvl="52" quality="RARE" boe="no" icon="Inv_drink_01.png"/>
 		<mutex item_id="20251"/>

--- a/Equipment/Item/Item.cpp
+++ b/Equipment/Item/Item.cpp
@@ -29,6 +29,7 @@
 #include "Nightfall.h"
 #include "NoEffectSelfBuff.h"
 #include "ResourceGainProc.h"
+#include "SanctifiedOrb.h"
 #include "SpellRankGroup.h"
 #include "Stats.h"
 #include "Target.h"
@@ -332,6 +333,10 @@ void Item::set_uses() {
         else if (use_name == "DEVILSAUR_EYE") {
             Buff* buff = new DevilsaurEye(pchar);
             spell = new UseTrinket(pchar, name, icon, 120, buff);
+        }
+        else if (use_name == "SANCTIFIED_ORB") {
+            Buff* buff = new SanctifiedOrb(pchar);
+            spell = new UseTrinket(pchar, name, icon, 180, buff);
         }
         else if (use_name == "JOM_GABBAR") {
             Buff* buff = new JomGabbar(pchar);

--- a/QML/Assets/items/Inv_misc_gem_pearl_04.png
+++ b/QML/Assets/items/Inv_misc_gem_pearl_04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ae518c955b268ad8f8ad149fa9c2681a34eaaca4dcf142b1ddaf0ebb24691e3
+size 4921

--- a/QML/Assets/items/Inv_misc_ticket_tarot_maelstrom_01.png
+++ b/QML/Assets/items/Inv_misc_ticket_tarot_maelstrom_01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f06f7356a7e5ddd6ec41595a96c879c9030bb1667b88beb030c724d2584f7bb1
+size 7566

--- a/Rotation/Rotations/Paladin/SealOfCommand.xml
+++ b/Rotation/Rotations/Paladin/SealOfCommand.xml
@@ -37,7 +37,7 @@
     <cast_if name="Slayer's Crest"/>
     <cast_if name="Earthstrike"/>
     <cast_if name="Zandalarian Hero Medallion"/>
-    <cast_if name="Diamond Flask"/>
+    <cast_if name="Sanctified Orb"/>
     <cast_if name="Cloudkeeper Legplates"/>
 
     <cast_if name="Mana Potion"/>

--- a/Rotation/Rotations/Paladin/SealOfTheCrusader.xml
+++ b/Rotation/Rotations/Paladin/SealOfTheCrusader.xml
@@ -27,7 +27,7 @@
     <cast_if name="Slayer's Crest"/>
     <cast_if name="Earthstrike"/>
     <cast_if name="Zandalarian Hero Medallion"/>
-    <cast_if name="Diamond Flask"/>
+    <cast_if name="Sanctified Orb"/>
     <cast_if name="Cloudkeeper Legplates"/>
 
     <cast_if name="Mana Potion"/>

--- a/Test/Rotation/TestRotationFileReader.cpp
+++ b/Test/Rotation/TestRotationFileReader.cpp
@@ -189,7 +189,7 @@ void TestRotationFileReader::test_paladin_seal_of_the_crusader() {
         "Slayer's Crest",
         "Earthstrike",
         "Zandalarian Hero Medallion",
-        "Diamond Flask",
+        "Sanctified Orb",
         "Cloudkeeper Legplates",
         "Mana Potion",
         "Demonic Rune",

--- a/qml.qrc
+++ b/qml.qrc
@@ -1001,5 +1001,6 @@
         <file>QML/Assets/spell/Spell_arcane_teleportorgrimmar.png</file>
         <file>QML/Assets/misc/Inv_drink_milk_05.png</file>
         <file>QML/Assets/items/Inv_gauntlets_05.png</file>
+        <file>QML/Assets/items/Inv_misc_ticket_tarot_maelstrom_01.png</file>
     </qresource>
 </RCC>

--- a/qml.qrc
+++ b/qml.qrc
@@ -1002,5 +1002,6 @@
         <file>QML/Assets/misc/Inv_drink_milk_05.png</file>
         <file>QML/Assets/items/Inv_gauntlets_05.png</file>
         <file>QML/Assets/items/Inv_misc_ticket_tarot_maelstrom_01.png</file>
+        <file>QML/Assets/items/Inv_misc_gem_pearl_04.png</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Maelstrom's proc rate might be highly inaccurate and will need some adjustments once P3 hits. I couldn't really find any reliable information; in some comments on Wowhead it even says the proc rate depends on weapon speed (ppm). Seems like it wasn't always right on private servers either. 

As for the other commit, I hope I adjusted everything correctly. :) 
