### PR TITLE
Add a tooltip on mouseover in equipment tab

### DIFF
--- a/GUI/GUIControl.cpp
+++ b/GUI/GUIControl.cpp
@@ -1657,72 +1657,12 @@ QVariantList GUIControl::getTooltip(const QString& slot_string) {
     if (slot_string == "QUIVER")
         item = current_char->get_equipment()->get_quiver();
 
-    if (item == nullptr)
-        return QVariantList();
+    return get_tooltip_from_item(item);
+}
 
-    QString boe_string = item->get_value("boe") == "yes" ? "Binds when equipped" :
-                                                           "Binds when picked up";
-    QString unique = item->get_value("unique") == "yes" ? "Unique" :
-                                                          "";
-
-    QString slot = item->get_value("slot");
-    QString dmg_range = "";
-    QString weapon_speed = "";
-    QString dps = "";
-
-    if (slot == "1H")
-        set_weapon_tooltip(item, slot, "One-hand", dmg_range, weapon_speed, dps);
-    else if (slot == "MH")
-        set_weapon_tooltip(item, slot, "Main Hand", dmg_range, weapon_speed, dps);
-    else if (slot == "OH")
-        set_weapon_tooltip(item, slot, "Offhand", dmg_range, weapon_speed, dps);
-    else if (slot == "2H")
-        set_weapon_tooltip(item, slot, "Two-hand", dmg_range, weapon_speed, dps);
-    else if (slot == "RANGED") {
-        const QSet<QString> ranged_weapon_classes = {"Hunter", "Warrior", "Rogue", "Mage", "Warlock", "Priest"};
-        if (ranged_weapon_classes.contains(current_char->class_name))
-            set_weapon_tooltip(item, slot, "Ranged", dmg_range, weapon_speed, dps);
-    }
-    else if (slot == "PROJECTILE")
-        set_projectile_tooltip(item, slot, dps);
-    else if (slot == "RING")
-        slot = "Finger";
-    else if (slot == "GLOVES")
-        slot = "Hands";
-    else if (slot == "BELT")
-        slot = "Waist";
-    else if (slot == "BOOTS")
-        slot = "Feet";
-    else if (slot == "SHOULDERS")
-        slot = "Shoulder";
-    else
-        slot = get_initial_upper_case_rest_lower_case(slot);
-
-    QString class_restriction = "";
-    set_class_restriction_tooltip(item, class_restriction);
-
-    QString lvl_req = QString("Requires level %1").arg(item->get_value("req_lvl"));
-
-    QVariantList tooltip_info = {
-        QVariant(item->name),
-        QVariant(item->get_value("quality")),
-        QVariant(boe_string),
-        QVariant(unique),
-        QVariant(slot),
-        QVariant(get_initial_upper_case_rest_lower_case(item->get_value("type"))),
-        QVariant(dmg_range),
-        QVariant(weapon_speed),
-        QVariant(dps),
-        QVariant(item->get_base_stat_tooltip()),
-        QVariant(class_restriction),
-        QVariant(lvl_req),
-        QVariant(item->get_equip_effect_tooltip()),
-        QVariant(item->get_value("flavour_text"))
-    };
-
-    set_set_bonus_tooltip(item, tooltip_info);
-
-    return tooltip_info;
+QVariantList GUIControl::getTooltip(const int item_id) {
+    Item* item = this->equipment_db->get_item(item_id);
+    return get_tooltip_from_item(item);
 }
 
 void GUIControl::set_weapon_tooltip(Item*& item, QString& slot, QString type, QString& dmg_range, QString& wpn_speed, QString& dps) {
@@ -2012,4 +1952,73 @@ void GUIControl::activate_gui_setting(const QStringRef& name, const QString& val
         sim_settings->set_num_threads(value.toInt());
     else if (name == "sim_option")
         sim_settings->add_sim_option(static_cast<SimOption::Name>(value.toInt()));
+}
+
+QVariantList GUIControl::get_tooltip_from_item(Item* item) {
+    if (item == nullptr)
+        return QVariantList();
+
+    QString boe_string = item->get_value("boe") == "yes" ? "Binds when equipped" :
+                                                           "Binds when picked up";
+    QString unique = item->get_value("unique") == "yes" ? "Unique" :
+                                                          "";
+
+    QString slot = item->get_value("slot");
+    QString dmg_range = "";
+    QString weapon_speed = "";
+    QString dps = "";
+
+    if (slot == "1H")
+        set_weapon_tooltip(item, slot, "One-hand", dmg_range, weapon_speed, dps);
+    else if (slot == "MH")
+        set_weapon_tooltip(item, slot, "Main Hand", dmg_range, weapon_speed, dps);
+    else if (slot == "OH")
+        set_weapon_tooltip(item, slot, "Offhand", dmg_range, weapon_speed, dps);
+    else if (slot == "2H")
+        set_weapon_tooltip(item, slot, "Two-hand", dmg_range, weapon_speed, dps);
+    else if (slot == "RANGED") {
+        const QSet<QString> ranged_weapon_classes = {"Hunter", "Warrior", "Rogue", "Mage", "Warlock", "Priest"};
+        if (ranged_weapon_classes.contains(current_char->class_name))
+            set_weapon_tooltip(item, slot, "Ranged", dmg_range, weapon_speed, dps);
+    }
+    else if (slot == "PROJECTILE")
+        set_projectile_tooltip(item, slot, dps);
+    else if (slot == "RING")
+        slot = "Finger";
+    else if (slot == "GLOVES")
+        slot = "Hands";
+    else if (slot == "BELT")
+        slot = "Waist";
+    else if (slot == "BOOTS")
+        slot = "Feet";
+    else if (slot == "SHOULDERS")
+        slot = "Shoulder";
+    else
+        slot = get_initial_upper_case_rest_lower_case(slot);
+
+    QString class_restriction = "";
+    set_class_restriction_tooltip(item, class_restriction);
+
+    QString lvl_req = QString("Requires level %1").arg(item->get_value("req_lvl"));
+
+    QVariantList tooltip_info = {
+        QVariant(item->name),
+        QVariant(item->get_value("quality")),
+        QVariant(boe_string),
+        QVariant(unique),
+        QVariant(slot),
+        QVariant(get_initial_upper_case_rest_lower_case(item->get_value("type"))),
+        QVariant(dmg_range),
+        QVariant(weapon_speed),
+        QVariant(dps),
+        QVariant(item->get_base_stat_tooltip()),
+        QVariant(class_restriction),
+        QVariant(lvl_req),
+        QVariant(item->get_equip_effect_tooltip()),
+        QVariant(item->get_value("flavour_text"))
+    };
+
+    set_set_bonus_tooltip(item, tooltip_info);
+
+    return tooltip_info;
 }

--- a/GUI/GUIControl.h
+++ b/GUI/GUIControl.h
@@ -170,6 +170,7 @@ public:
     Q_PROPERTY(QString quiverIcon READ get_quiver_icon NOTIFY equipmentChanged)
 
     Q_INVOKABLE QVariantList getTooltip(const QString& slot_string);
+    Q_INVOKABLE QVariantList getTooltip(const int item_id);
 
     Q_INVOKABLE void selectSlot(const QString& slot_string);
     Q_INVOKABLE void setSlot(const QString& slot_string, const int item_id, const uint affix_id = 0);
@@ -432,6 +433,8 @@ private:
     void save_gui_settings();
     void load_gui_settings();
     void activate_gui_setting(const QStringRef &name, const QString& value);
+
+    QVariantList get_tooltip_from_item(Item* item);
 
     EquipmentDb* equipment_db;
     RandomAffixes* random_affixes_db;

--- a/QML/Equipment.qml
+++ b/QML/Equipment.qml
@@ -79,6 +79,7 @@ Rectangle {
                     ScrollBar.vertical.policy: ScrollBar.AlwaysOn
 
                     ListView {
+                        id: weaponListView
                         model: weaponModel
                         boundsBehavior: Flickable.StopAtBounds
 
@@ -101,8 +102,6 @@ Rectangle {
                             onEntryClicked: {
                                 if (entryRandomAffix) {
                                     equipment.setRandomAffixesModelId(itemid)
-
-                                    var pos = mapToItem(itemListView, 0, 0)
                                     randomWeaponPopup.x = mouseX
                                     randomWeaponPopup.y = mouseY
                                     randomWeaponPopup.open()
@@ -110,6 +109,22 @@ Rectangle {
                                 else {
                                     equipment.setSlot(eqRect.state, itemid)
                                 }
+                            }
+
+                            onShowTooltip: {
+                                weaponTooltip.itemId = itemid
+                                weaponTooltip.updateTooltip()
+                                weaponTooltip.visible = true;
+                            }
+
+                            onUpdateTooltip: {
+                                var pos = mapToItem(weaponListView, mouseX, mouseY)
+                                weaponTooltip.x = pos.x > weaponListView.width / 2 ? pos.x - 12 - weaponTooltip.width : pos.x + 12
+                                weaponTooltip.y = pos.y > weaponListView.height / 2 ? pos.y - weaponTooltip.getTooltipHeight() : pos.y
+                            }
+
+                            onHideTooltip: {
+                                weaponTooltip.visible = false;
                             }
 
                             Popup {
@@ -127,6 +142,11 @@ Rectangle {
                                     }
                                 }
                             }
+                        }
+
+                        EquipmentTooltip {
+                            id: weaponTooltip
+                            useId: true
                         }
                     }
                 }
@@ -160,8 +180,6 @@ Rectangle {
                             onEntryClicked: {
                                 if (entryRandomAffix) {
                                     equipment.setRandomAffixesModelId(itemid)
-
-                                    var pos = mapToItem(itemListView, 0, 0)
                                     randomEquipmentPopup.x = mouseX
                                     randomEquipmentPopup.y = mouseY
                                     randomEquipmentPopup.open()
@@ -169,6 +187,22 @@ Rectangle {
                                 else {
                                     equipment.setSlot(eqRect.state, itemid)
                                 }
+                            }
+
+                            onShowTooltip: {
+                                itemTooltip.itemId = itemid
+                                itemTooltip.updateTooltip()
+                                itemTooltip.visible = true;
+                            }
+
+                            onUpdateTooltip: {
+                                var pos = mapToItem(itemListView, mouseX, mouseY)
+                                itemTooltip.x = pos.x > itemListView.width / 2 ? pos.x - 12 - itemTooltip.width : pos.x + 12
+                                itemTooltip.y = pos.y > itemListView.height / 2 ? pos.y - itemTooltip.getTooltipHeight() : pos.y
+                            }
+
+                            onHideTooltip: {
+                                itemTooltip.visible = false;
                             }
 
                             Popup {
@@ -186,6 +220,11 @@ Rectangle {
                                     }
                                 }
                             }
+                        }
+
+                        EquipmentTooltip {
+                            id: itemTooltip
+                            useId: true
                         }
                     }
                 }

--- a/QML/EquipmentTooltip.qml
+++ b/QML/EquipmentTooltip.qml
@@ -2,6 +2,9 @@ import QtQuick 2.0
 
 RectangleBorders {
     property string slotString
+    property int itemId
+    property bool useId: false
+
     property bool showDurabilityInTooltip: hasDurability()
     property bool showTypeInTooltip: showDurabilityInTooltip
     property bool slotEquipped: false
@@ -31,7 +34,7 @@ RectangleBorders {
     }
 
     function updateTooltip() {
-        var tooltipInfo = equipment.getTooltip(slotString)
+        var tooltipInfo = useId ? equipment.getTooltip(itemId) : equipment.getTooltip(slotString)
         if (tooltipInfo.length === 0) {
             slotEquipped = false;
             return;

--- a/QML/ItemEntry.qml
+++ b/QML/ItemEntry.qml
@@ -5,6 +5,9 @@ RectangleBorders {
     height: 45
 
     signal entryClicked(int mouseX, int mouseY);
+    signal showTooltip();
+    signal updateTooltip(int itemId, int mouseX, int mouseY);
+    signal hideTooltip();
 
     property int itemid
     property string entryName
@@ -30,6 +33,18 @@ RectangleBorders {
 
             console.log("Clicked", entryName)
             entryClicked(mouse.x, mouse.y);
+        }
+
+        onEntered: {
+            showTooltip();
+        }
+
+        onExited: {
+            hideTooltip();
+        }
+
+        onPositionChanged: {
+            updateTooltip(itemid, mouseX, mouseY);
         }
     }
 

--- a/QML/ItemEntryWeapon.qml
+++ b/QML/ItemEntryWeapon.qml
@@ -5,6 +5,9 @@ RectangleBorders {
     height: 45
 
     signal entryClicked(int mouseX, int mouseY);
+    signal showTooltip();
+    signal updateTooltip(int itemId, int mouseX, int mouseY);
+    signal hideTooltip();
 
     property int itemid
     property string entryName
@@ -32,6 +35,18 @@ RectangleBorders {
 
             console.log("Clicked", entryName)
             entryClicked(mouse.x, mouse.y);
+        }
+
+        onEntered: {
+            showTooltip();
+        }
+
+        onExited: {
+            hideTooltip();
+        }
+
+        onPositionChanged: {
+            updateTooltip(itemid, mouseX, mouseY);
         }
     }
 


### PR DESCRIPTION
Fix #132 

![item_tooltips](https://user-images.githubusercontent.com/29523726/74594484-6ff56d00-5037-11ea-847c-bff9d973eb7d.gif)
