### PR TITLE
Update shadowcraft 6pc proc rate to 3.5%

### DIFF
--- a/Equipment/SetBonusControl.cpp
+++ b/Equipment/SetBonusControl.cpp
@@ -65,7 +65,7 @@ void SetBonusControl::equip_item(const int item_id) {
                                                                         "Shadowcraft 6 set",
                                                                         "Assets/items/Inv_helmet_41.png",
                                                                         {ProcInfo::MainhandSpell, ProcInfo::MainhandSwing, ProcInfo::OffhandSwing},
-                                                                        0.01, ResourceType::Energy, 35, 35);
+                                                                        0.035, ResourceType::Energy, 35, 35);
             active_procs["SHADOWCRAFT_GAIN"]->enable_proc();
             break;
         }


### PR DESCRIPTION
Testing shows a bit more than 1%. See Zatar's explanation at https://youtu.be/e1e38Xl7Vs4?t=318