### PR TITLE
Add <cmath> to files that need it

### DIFF
--- a/Class/Druid/Spells/Moonfire.cpp
+++ b/Class/Druid/Spells/Moonfire.cpp
@@ -12,6 +12,8 @@
 #include "SimSettings.h"
 #include "Utils/Check.h"
 
+#include <cmath>
+
 Moonfire::Moonfire(Druid* pchar, DruidSpells* druid_spells, const int spell_rank) :
     SpellPeriodic("Moonfire", "Assets/spell/Spell_nature_starfall.png", pchar, nullptr,
                   RestrictedByGcd::Yes, ResourceType::Mana, 3.0, 0, spell_rank),

--- a/Class/Druid/Spells/Starfire.cpp
+++ b/Class/Druid/Spells/Starfire.cpp
@@ -11,6 +11,8 @@
 #include "SimSettings.h"
 #include "Utils/Check.h"
 
+#include <cmath>
+
 Starfire::Starfire(Druid* pchar, DruidSpells* druid_spells, const int spell_rank) :
     Spell("Starfire", "Assets/spell/Spell_arcane_starfire.png", pchar, new CooldownControl(pchar, 0.0), RestrictedByGcd::Yes, ResourceType::Mana, 0, spell_rank),
     CastingTimeRequirer(pchar, SuppressibleCast::Yes, 3500),

--- a/Class/Druid/Spells/Wrath.cpp
+++ b/Class/Druid/Spells/Wrath.cpp
@@ -11,6 +11,8 @@
 #include "SimSettings.h"
 #include "Utils/Check.h"
 
+#include <cmath>
+
 Wrath::Wrath(Druid* pchar, DruidSpells* druid_spells, const int spell_rank) :
     Spell("Wrath", "Assets/items/Spell_nature_abolishmagic.png", pchar, new CooldownControl(pchar, 0.0), RestrictedByGcd::Yes, ResourceType::Mana, 0, spell_rank),
     CastingTimeRequirer(pchar, SuppressibleCast::Yes, 2000),

--- a/Class/Mage/Spells/Fireball.cpp
+++ b/Class/Mage/Spells/Fireball.cpp
@@ -13,6 +13,8 @@
 #include "StatisticsResource.h"
 #include "Utils/Check.h"
 
+#include <cmath>
+
 Fireball::Fireball(Mage* pchar, MageSpells* mage_spells, const int spell_rank) :
     Spell("Fireball", "Assets/spell/Spell_fire_flamebolt.png", pchar, new CooldownControl(pchar, 0.0), RestrictedByGcd::Yes, ResourceType::Mana, 0, spell_rank),
     CastingTimeRequirer(pchar, SuppressibleCast::Yes, 3500),

--- a/Class/Mage/Spells/Frostbolt.cpp
+++ b/Class/Mage/Spells/Frostbolt.cpp
@@ -14,6 +14,8 @@
 #include "StatisticsResource.h"
 #include "Utils/Check.h"
 
+#include <cmath>
+
 Frostbolt::Frostbolt(Mage* pchar, MageSpells* mage_spells, Proc* winters_chill, const int spell_rank) :
     Spell("Frostbolt", "Assets/spell/Spell_frost_frostbolt02.png", pchar, new CooldownControl(pchar, 0.0), RestrictedByGcd::Yes, ResourceType::Mana, 0, spell_rank),
     CastingTimeRequirer(pchar, SuppressibleCast::Yes, 3000),

--- a/Class/Mage/Spells/Scorch.cpp
+++ b/Class/Mage/Spells/Scorch.cpp
@@ -12,6 +12,8 @@
 #include "StatisticsResource.h"
 #include "Utils/Check.h"
 
+#include <cmath>
+
 Scorch::Scorch(Mage* pchar, MageSpells* mage_spells, Proc* proc, const int spell_rank) :
     Spell("Scorch", "Assets/spell/Spell_fire_soulburn.png", pchar, new CooldownControl(pchar, 0.0), RestrictedByGcd::Yes, ResourceType::Mana, 0, spell_rank),
     CastingTimeRequirer(pchar, SuppressibleCast::Yes, 1500),

--- a/Class/Warrior/Warrior.cpp
+++ b/Class/Warrior/Warrior.cpp
@@ -22,6 +22,8 @@
 #include "WarriorSpells.h"
 #include "Weapon.h"
 
+#include <cmath>
+
 Warrior::Warrior(Race* race, EquipmentDb* equipment_db, SimSettings* sim_settings, RaidControl* raid_control, const int party, const int member) :
     Character("Warrior", "#C79C6E", race, sim_settings, raid_control, party, member) {
     available_races.append("Dwarf");

--- a/Statistics/NumberCruncher.cpp
+++ b/Statistics/NumberCruncher.cpp
@@ -9,6 +9,8 @@
 #include "StatisticsSpell.h"
 #include "Utils/Check.h"
 
+#include <cmath>
+
 NumberCruncher::~NumberCruncher() {
     reset();
 }


### PR DESCRIPTION
This fails to build on non-Windows systems. I'm guessing something in Windows headers brings cmath in that's not standard.