### PR TITLE
Add BattleStanceBuff for Warriors

### DIFF
--- a/Class/Warrior/Buffs/BattleStanceBuff.cpp
+++ b/Class/Warrior/Buffs/BattleStanceBuff.cpp
@@ -1,0 +1,17 @@
+#include "BattleStanceBuff.h"
+
+#include "CharacterStats.h"
+#include "Warrior.h"
+
+BattleStanceBuff::BattleStanceBuff(Warrior* warrior):
+    SelfBuff(warrior, "Battle Stance", NO_ICON, BuffDuration::PERMANENT, 1),
+    warrior(warrior)
+{
+    this->hidden = true;
+}
+
+void BattleStanceBuff::buff_effect_when_applied() {
+}
+
+void BattleStanceBuff::buff_effect_when_removed() {
+}

--- a/Class/Warrior/Buffs/BattleStanceBuff.h
+++ b/Class/Warrior/Buffs/BattleStanceBuff.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "SelfBuff.h"
+
+class Warrior;
+
+class BattleStanceBuff: public SelfBuff {
+public:
+    BattleStanceBuff(Warrior* warrior);
+
+private:
+    Warrior* warrior;
+
+    void buff_effect_when_applied() override;
+    void buff_effect_when_removed() override;
+};

--- a/Class/Warrior/Warrior.cpp
+++ b/Class/Warrior/Warrior.cpp
@@ -175,6 +175,9 @@ void Warrior::new_stance_effect() {
     case WarriorStances::Defensive:
         warr_spells->get_defensive_stance_buff()->apply_buff();
         break;
+    case WarriorStances::Battle:
+        warr_spells->get_battle_stance_buff()->apply_buff();
+        break;
     }
 
     if (this->rage->current > stance_rage_remainder)
@@ -207,6 +210,9 @@ void Warrior::switch_to_berserker_stance() {
     case WarriorStances::Defensive:
         warr_spells->get_defensive_stance_buff()->cancel_buff();
         break;
+    case WarriorStances::Battle:
+        warr_spells->get_battle_stance_buff()->cancel_buff();
+        break;
     }
 
     this->stance = WarriorStances::Berserker;
@@ -217,6 +223,9 @@ void Warrior::switch_to_defensive_stance() {
     switch (this->stance) {
     case WarriorStances::Berserker:
         warr_spells->get_berserker_stance_buff()->cancel_buff();
+        break;
+    case WarriorStances::Battle:
+        warr_spells->get_battle_stance_buff()->cancel_buff();
         break;
     }
 

--- a/Class/Warrior/WarriorSpells.cpp
+++ b/Class/Warrior/WarriorSpells.cpp
@@ -4,6 +4,7 @@
 #include "BattleShout.h"
 #include "BattleShoutBuff.h"
 #include "BattleStance.h"
+#include "BattleStanceBuff.h"
 #include "BerserkerRage.h"
 #include "BerserkerStance.h"
 #include "BerserkerStanceBuff.h"
@@ -112,7 +113,7 @@ WarriorSpells::WarriorSpells(Warrior* warrior) :
     add_spell_group({warr_mh_attack});
     add_spell_group({warr_oh_attack});
 
-    this->battle_stance_buff = new NoEffectSelfBuff(warrior, BuffDuration::PERMANENT, "Battle Stance");
+    this->battle_stance_buff = new BattleStanceBuff(warrior);
     this->berserker_stance_buff = new BerserkerStanceBuff(warrior);
     this->defensive_stance_buff = new DefensiveStanceBuff(warrior);
     this->flurry = new Flurry(warrior);
@@ -259,6 +260,10 @@ Buff* WarriorSpells::get_flurry() const {
 
 Buff* WarriorSpells::get_berserker_stance_buff() const {
     return this->berserker_stance_buff;
+}
+
+Buff* WarriorSpells::get_battle_stance_buff() const {
+    return this->battle_stance_buff;
 }
 
 Buff* WarriorSpells::get_defensive_stance_buff() const {

--- a/Class/Warrior/WarriorSpells.h
+++ b/Class/Warrior/WarriorSpells.h
@@ -4,6 +4,7 @@
 
 class AngerManagement;
 class BattleStance;
+class BattleStanceBuff;
 class BerserkerRage;
 class BerserkerStance;
 class BerserkerStanceBuff;
@@ -57,6 +58,7 @@ public:
     Slam* get_slam() const;
     Whirlwind* get_whirlwind() const;
 
+    Buff* get_battle_stance_buff() const;
     Buff* get_berserker_stance_buff() const;
     Buff* get_overpower_buff() const;
     Buff* get_defensive_stance_buff() const;
@@ -94,7 +96,7 @@ private:
     Whirlwind* whirlwind;
 
     BerserkerStanceBuff* berserker_stance_buff;
-    Buff* battle_stance_buff;
+    BattleStanceBuff* battle_stance_buff;
     Buff* overpower_buff;
     DefensiveStanceBuff* defensive_stance_buff;
     Buff* hs_buff;

--- a/ClassicSim.pro
+++ b/ClassicSim.pro
@@ -294,6 +294,7 @@ SOURCES += main.cpp \
     Class/Warrior/Spells/BattleStance.cpp \
     Class/Warrior/Spells/BerserkerStance.cpp \
     Class/Warrior/Buffs/BerserkerStanceBuff.cpp \
+    Class/Warrior/Buffs/BattleStanceBuff.cpp \
     Test/Warrior/Spells/TestBerserkerStance.cpp \
     Character/Race/Racials/BloodFury.cpp \
     Character/Race/Racials/BloodFuryBuff.cpp \
@@ -782,6 +783,7 @@ HEADERS += \
     Test/Warrior/Spells/TestRecklessness.h \
     Class/Warrior/Spells/BattleStance.h \
     Class/Warrior/Spells/BerserkerStance.h \
+    Class/Warrior/Buffs/BattleStanceBuff.h \
     Class/Warrior/Buffs/BerserkerStanceBuff.h \
     Test/Warrior/Spells/TestBerserkerStance.h \
     Character/Race/Racials/BloodFury.h \


### PR DESCRIPTION
Currently this is a trivial no-op stance. However, in order to account
for threat modifiers in each stance we will need a stance to apply and
remove buffs (90% for battle/berserker and 150% for defensive).