### PR TITLE
Add Block Value to CharacterStats and Stats

### DIFF
--- a/Character/CharacterStats.cpp
+++ b/Character/CharacterStats.cpp
@@ -96,6 +96,10 @@ Equipment* CharacterStats::get_equipment() const {
     return this->equipment;
 }
 
+unsigned CharacterStats::get_block_value() const {
+    return static_cast<unsigned>(base_stats->get_block_value() + equipment->get_stats()->get_block_value());
+}
+
 unsigned CharacterStats::get_strength() const {
     return static_cast<unsigned>(
         round(strength_mod * (base_stats->get_strength() + equipment->get_stats()->get_strength() + pchar->get_race()->get_base_strength())));
@@ -624,6 +628,14 @@ void CharacterStats::increase_casting_speed_flat_reduction(const unsigned value)
 void CharacterStats::decrease_casting_speed_flat_reduction(const unsigned value) {
     check((casting_speed_flat_reduction >= value), "Underflow reduction of flat casting speed");
     casting_speed_flat_reduction -= value;
+}
+
+void CharacterStats::increase_block_value(const unsigned value) {
+    base_stats->increase_block_value(value);
+}
+
+void CharacterStats::decrease_block_value(const unsigned value) {
+    base_stats->decrease_block_value(value);
 }
 
 void CharacterStats::increase_strength(const unsigned value) {

--- a/Character/CharacterStats.h
+++ b/Character/CharacterStats.h
@@ -55,6 +55,10 @@ public:
     void increase_casting_speed_flat_reduction(const unsigned value);
     void decrease_casting_speed_flat_reduction(const unsigned value);
 
+    unsigned get_block_value() const;
+    void increase_block_value(const unsigned value);
+    void decrease_block_value(const unsigned value);
+
     unsigned get_strength() const;
     void increase_strength(const unsigned value);
     void decrease_strength(const unsigned value);

--- a/Character/Stats.cpp
+++ b/Character/Stats.cpp
@@ -198,6 +198,9 @@ void Stats::add(const QString& key, const QString& value) {
     } else if (key == "DEFENSE") {
         this->increase_defense(value.toInt());
         this->equip_effects_tooltip.append(QString("Equip: Increased Defense +%1.").arg(value));
+    } else if (key == "BLOCK_VALUE") {
+      this->increase_block_value(value.toInt());
+      this->equip_effects_tooltip.append(QString("Equip: Increased Block Value +%1.").arg(value));
     } else if (key == "DODGE_CHANCE") {
         this->increase_dodge(value.toDouble());
         this->equip_effects_tooltip.append(QString("Equip: Increases your chance to dodge an attack by %1%.").arg(value));
@@ -242,6 +245,8 @@ void Stats::add(const Stats* rhs) {
     increase_stamina(rhs->get_stamina());
     increase_intellect(rhs->get_intellect());
     increase_spirit(rhs->get_spirit());
+
+    increase_block_value(rhs->get_block_value());
 
     increase_axe_skill(rhs->get_axe_skill());
     increase_dagger_skill(rhs->get_dagger_skill());
@@ -333,6 +338,8 @@ void Stats::remove(const Stats* rhs) {
     decrease_stamina(rhs->get_stamina());
     decrease_intellect(rhs->get_intellect());
     decrease_spirit(rhs->get_spirit());
+
+    decrease_block_value(rhs->get_block_value());
 
     decrease_axe_skill(rhs->get_axe_skill());
     decrease_dagger_skill(rhs->get_dagger_skill());
@@ -442,6 +449,10 @@ unsigned Stats::get_spirit() const {
     return spirit;
 }
 
+unsigned Stats::get_block_value() const {
+    return block_value;
+}
+
 void Stats::increase_strength(const unsigned increase) {
     strength += increase;
 }
@@ -488,6 +499,14 @@ void Stats::increase_armor(const int increase) {
 
 void Stats::decrease_armor(const int decrease) {
     armor -= decrease;
+}
+
+void Stats::increase_block_value(const int increase) {
+    block_value += increase;
+}
+
+void Stats::decrease_block_value(const int decrease) {
+    block_value -= decrease;
 }
 
 void Stats::increase_defense(const int increase) {

--- a/Character/Stats.h
+++ b/Character/Stats.h
@@ -45,6 +45,10 @@ public:
     void increase_defense(const int);
     void decrease_defense(const int);
 
+    unsigned get_block_value() const;
+    void increase_block_value(const int);
+    void decrease_block_value(const int);
+
     void increase_dodge(const double);
     void decrease_dodge(const double);
 
@@ -198,6 +202,7 @@ private:
     // Defensive stats
     int armor {0};
     int defense {0};
+    int block_value {0};
     double dodge_chance {0.0};
     double parry_chance {0.0};
 


### PR DESCRIPTION
This simply stubs them out so that they are merely usable by other
classes. Proper implementation for items that boost it and shields will
have to follow.