### PR TITLE
Make paladin rotation use judgement on cooldown

### DIFF
--- a/Rotation/Rotations/Paladin/SealOfCommand.xml
+++ b/Rotation/Rotations/Paladin/SealOfCommand.xml
@@ -14,6 +14,11 @@
         and buff_duration "Seal of the Crusader" greater 0
     </cast_if>
 
+    <cast_if name="Judgement">
+        buff_duration "Seal of Command" greater 0
+        and resource "Mana" greater 200
+    </cast_if>
+
     <cast_if name="Seal of Command">
         buff_duration "Judgement of the Crusader" greater 3
         and buff_duration "Seal of Command" less 3


### PR DESCRIPTION
Following #158, this improves paladin's DPS quite a bit, while still ensuring you don't run out of mana to keep SoC up. My goal is also to implement #60 eventually. 