### PR TITLE
Adding Warlock T2 Items

### DIFF
--- a/Equipment/EquipmentDb/Belts/cloth.xml
+++ b/Equipment/EquipmentDb/Belts/cloth.xml
@@ -181,6 +181,23 @@
 		</source>
 	</item>
 
+	<item id="16933" phase="3">
+		<info name="Nemesis Belt" type="CLOTH" slot="BELT" unique="no" req_lvl="60" item_lvl="76" quality="EPIC" boe="no" icon="Inv_belt_13.png"/>
+		<class_restriction class="WARLOCK"/>
+		<stats>
+			<stat type="ARMOR" value="65"/>
+			<stat type="INTELLECT" value="8"/>
+			<stat type="SPIRIT" value="6"/>
+			<stat type="STAMINA" value="18"/>
+			<stat type="SHADOW_RESISTANCE" value="10"/>
+			<stat type="SPELL_DAMAGE" value="25"/>
+			<stat type="SPELL_CRIT_CHANCE" value="0.01"/>
+		</stats>
+		<source>
+		Drops from Vaelastrasz the Corrupt in Blackwing Lair.
+		</source>
+	</item>
+
 	<item id="19388" phase="3">
 		<info name="Angelista's Grasp" type="CLOTH" slot="BELT" unique="no" req_lvl="60" item_lvl="77" quality="EPIC" boe="no" icon="Inv_belt_13.png"/>
 		<stats>

--- a/Equipment/EquipmentDb/Boots/cloth.xml
+++ b/Equipment/EquipmentDb/Boots/cloth.xml
@@ -231,6 +231,22 @@
 		</source>
 	</item>
 
+	<item id="16927" phase="3">
+		<info name="Nemesis Boots" type="CLOTH" slot="BOOTS" unique="no" req_lvl="60" item_lvl="76" quality="EPIC" boe="no" icon="Inv_boots_05.png"/>
+		<class_restriction class="WARLOCK"/>
+		<stats>
+			<stat type="ARMOR" value="80"/>
+			<stat type="INTELLECT" value="17"/>
+			<stat type="SPIRIT" value="6"/>
+			<stat type="STAMINA" value="20"/>
+			<stat type="FIRE_RESISTANCE" value="10"/>
+			<stat type="SPELL_DAMAGE" value="23"/>
+		</stats>
+		<source>
+		Drops from Broodlord Lashlayer in Blackwing Lair.
+		</source>
+	</item>
+
 	<item id="19391" phase="3">
 		<info name="Shimmering Geta" type="CLOTH" slot="BOOTS" unique="no" req_lvl="60" item_lvl="77" quality="EPIC" boe="no" icon="Inv_boots_cloth_01.png"/>
 		<stats>

--- a/Equipment/EquipmentDb/Chests/cloth.xml
+++ b/Equipment/EquipmentDb/Chests/cloth.xml
@@ -395,6 +395,24 @@
 		Drops from Nefarian in Blackwing Lair.
 		</source>
 	</item>
+	
+	<item id="16931" phase="3">
+		<info name="Nemesis Robes" type="CLOTH" slot="CHEST" unique="no" req_lvl="60" item_lvl="76" quality="EPIC" boe="no" icon="Inv_chest_leather_01.png"/>
+		<class_restriction class="WARLOCK"/>
+		<stats>
+			<stat type="ARMOR" value="116"/>
+			<stat type="INTELLECT" value="16"/>
+			<stat type="SPIRIT" value="8"/>
+			<stat type="STAMINA" value="26"/>
+			<stat type="FIRE_RESISTANCE" value="10"/>
+			<stat type="NATURE_RESISTANCE" value="10"/>
+			<stat type="SPELL_CRIT_CHANCE" value="0.01"/>
+			<stat type="SPELL_DAMAGE" value="32"/>
+		</stats>
+		<source>
+		Drops from Nefarian in Blackwing Lair.
+		</source>
+	</item>
 
 	<item id="19682" phase="4">
 		<info name="Bloodvine Vest" type="CLOTH" slot="CHEST" unique="no" req_lvl="60" item_lvl="65" quality="RARE" boe="yes" icon="Inv_chest_cloth_07.png"/>

--- a/Equipment/EquipmentDb/Gloves/cloth.xml
+++ b/Equipment/EquipmentDb/Gloves/cloth.xml
@@ -242,6 +242,23 @@
 		</source>
 	</item>
 
+	<item id="16928" phase="3">
+		<info name="Nemesis Gloves" type="CLOTH" slot="GLOVES" unique="no" req_lvl="60" item_lvl="76" quality="EPIC" boe="no" icon="Inv_gauntlets_19.png"/>
+		<class_restriction class="WARLOCK"/>
+		<stats>
+			<stat type="ARMOR" value="72"/>
+			<stat type="INTELLECT" value="15"/>
+			<stat type="STAMINA" value="17"/>
+			<stat type="SHADOW_RESISTANCE" value="10"/>
+			<stat type="HEALTH_PER_5" value="4"/>
+			<stat type="SPELL_CRIT_CHANCE" value="0.01"/>
+			<stat type="SPELL_DAMAGE" value="15"/>
+		</stats>
+		<source>
+		Drops from Ebonroc, Flamegor, Firemaw in Blackwing Lair.
+		</source>
+	</item>
+
 	<item id="19929" phase="4">
 		<info name="Bloodtinged Gloves" type="CLOTH" slot="GLOVES" unique="no" req_lvl="60" item_lvl="71" quality="RARE" boe="no" icon="Inv_gauntlets_16.png"/>
 		<stats>

--- a/Equipment/EquipmentDb/Helms/cloth.xml
+++ b/Equipment/EquipmentDb/Helms/cloth.xml
@@ -460,6 +460,24 @@
 		</source>
 	</item>
 
+	<item id="16929" phase="1">
+		<info name="Nemesis Skullcap" type="CLOTH" slot="HEAD" unique="no" req_lvl="60" item_lvl="76" quality="EPIC" boe="no" icon="Inv_helmet_08.png"/>
+		<class_restriction class="WARLOCK"/>
+		<stats>
+			<stat type="ARMOR" value="94"/>
+			<stat type="INTELLECT" value="16"/>
+			<stat type="SPIRIT" value="6"/>
+			<stat type="STAMINA" value="26"/>
+			<stat type="FROST_RESISTANCE" value="10"/>
+			<stat type="SHADOW_RESISTANCE" value="10"/>
+			<stat type="HEALTH_PER_5" value="4"/>
+			<stat type="SPELL_DAMAGE" value="32"/>
+		</stats>
+		<source>
+		Drops from Onyxia in Onyxia's Lair.
+		</source>
+	</item>
+
 	<item id="18526" phase="2">
 		<info name="Crown of the Ogre King" type="CLOTH" slot="HEAD" unique="no" req_lvl="58" item_lvl="63" quality="RARE" boe="no" icon="Inv_crown_01.png"/>
 		<stats>

--- a/Equipment/EquipmentDb/Legs/cloth.xml
+++ b/Equipment/EquipmentDb/Legs/cloth.xml
@@ -101,6 +101,23 @@
 		</source>
 	</item>
 
+	<item id="16930" phase="1">
+		<info name="Nemesis Leggings" type="CLOTH" slot="LEGS" unique="no" req_lvl="60" item_lvl="76" quality="EPIC" boe="no" icon="Inv_pants_07.png"/>
+		<class_restriction class="WARLOCK"/>
+		<stats>
+			<stat type="ARMOR" value="101"/>
+			<stat type="INTELLECT" value="16"/>
+			<stat type="SPIRIT" value="4"/>
+			<stat type="STAMINA" value="23"/>
+			<stat type="FIRE_RESISTANCE" value="10"/>
+			<stat type="ARCANE_RESISTANCE" value="10"/>
+			<stat type="SPELL_DAMAGE" value="39"/>
+		</stats>
+		<source>
+		Drops from Ragnaros in Molten Core.
+		</source>
+	</item>
+
 	<item id="18872" phase="1">
 		<info name="Manastorm Leggings" type="CLOTH" slot="LEGS" unique="no" req_lvl="60" item_lvl="63" quality="EPIC" boe="no" icon="Inv_pants_08.png"/>
 		<stats>

--- a/Equipment/EquipmentDb/Shoulders/cloth.xml
+++ b/Equipment/EquipmentDb/Shoulders/cloth.xml
@@ -516,6 +516,23 @@
 		</source>
 	</item>
 
+	<item id="16932" phase="3">
+		<info name="Nemesis Spaulders" type="CLOTH" slot="SHOULDERS" unique="no" req_lvl="60" item_lvl="76" quality="EPIC" boe="no" icon="Inv_shoulder_19.png"/>
+		<class_restriction class="WARLOCK"/>
+		<stats>
+			<stat type="ARMOR" value="87"/>
+			<stat type="INTELLECT" value="13"/>
+			<stat type="SPIRIT" value="6"/>
+			<stat type="STAMINA" value="20"/>
+			<stat type="FIRE_RESISTANCE" value="10"/>
+			<stat type="HEALTH_PER_5" value="4"/>
+			<stat type="SPELL_DAMAGE" value="23"/>
+		</stats>
+		<source>
+		Drops from Chromaggus in Blackwing Lair.
+		</source>
+	</item>
+
 	<item id="19845" phase="4">
 		<info name="Zandalar Illusionist's Mantle" type="CLOTH" slot="SHOULDERS" unique="no" req_lvl="60" item_lvl="61" quality="EPIC" boe="no" icon="Inv_shoulder_17.png"/>
 		<class_restriction class="MAGE"/>

--- a/Equipment/EquipmentDb/Wrists/cloth.xml
+++ b/Equipment/EquipmentDb/Wrists/cloth.xml
@@ -169,6 +169,21 @@
 		</source>
 	</item>
 
+	<item id="16934" phase="3">
+		<info name="Nemesis Bracers" type="CLOTH" slot="WRIST" unique="no" req_lvl="60" item_lvl="76" quality="EPIC" boe="no" icon="Inv_bracer_07.png"/>
+		<class_restriction class="WARLOCK"/>
+		<stats>
+			<stat type="ARMOR" value="51"/>
+			<stat type="INTELLECT" value="11"/>
+			<stat type="SPIRIT" value="6"/>
+			<stat type="STAMINA" value="21"/>
+			<stat type="SPELL_DAMAGE" value="15"/>
+		</stats>
+		<source>
+		Drops from Razorgore the Untamed in Blackwing Lair.
+		</source>
+	</item>
+
 	<item id="20626" phase="4">
 		<info name="Black Bark Wristbands" type="CLOTH" slot="WRIST" unique="no" req_lvl="60" item_lvl="71" quality="EPIC" boe="no" icon="Inv_bracer_07.png"/>
 		<stats>

--- a/Equipment/Item/ItemStatsEnum.cpp
+++ b/Equipment/Item/ItemStatsEnum.cpp
@@ -49,6 +49,8 @@ ItemStats get_item_stats_from_string(const QString& item_stat) {
         return ItemStats::SpellCrit;
     else if (item_stat == "MANA_PER_5")
         return ItemStats::ManaPer5;
+    else if (item_stat == "HEALTH_PER_5")
+        return ItemStats::HealthPer5;
     else if (item_stat == "MANA_SKILL_REDUCTION")
         return ItemStats::ManaSkillReduction;
     else if (item_stat == "SPELL_PENETRATION")


### PR DESCRIPTION
Part of https://github.com/timhul/ClassicSim/issues/167

I added the XML for all eight T2 Warlock items.
It seemed like HEALTH_PER_5 was missing an ItemStatsEnum entry. Added.

This is my first commit and I'm new to this. I haven't tested, whether it's actually working, since my dev environment for this project isn't setup (yet). This is mostly copy pasta from the corresponding Netherwind items, so it has a good chance of working. I have verified, that the assets (item graphics) actually exist.