### PR TITLE
Bear dps and tps

### DIFF
--- a/Class/Druid/Buffs/BearFormBuff.cpp
+++ b/Class/Druid/Buffs/BearFormBuff.cpp
@@ -1,0 +1,153 @@
+#include "BearFormBuff.h"
+
+#include <cmath>
+
+#include "CharacterStats.h"
+#include "Druid.h"
+#include "Equipment.h"
+#include "Proc.h"
+
+BearFormBuff::BearFormBuff(Druid* pchar, Buff* leader_of_the_pack, Proc* furor) :
+    SelfBuff(pchar, "Bear Form", "Assets/ability/Ability_racial_bearform.png", BuffDuration::PERMANENT, 0),
+    TalentRequirer({
+        new TalentRequirerInfo("Sharpened Claws", 3, DisabledAtZero::No),
+        new TalentRequirerInfo("Predatory Strikes", 3, DisabledAtZero::No),
+        new TalentRequirerInfo("Heart of the Wild", 5, DisabledAtZero::No),
+        new TalentRequirerInfo("Leader of the Pack", 1, DisabledAtZero::No),
+        new TalentRequirerInfo("Feral Instinct", 5, DisabledAtZero::No),
+    }),
+    druid(pchar),
+    leader_of_the_pack(leader_of_the_pack),
+    furor(furor),
+    threat_mod(30) {}
+
+void BearFormBuff::buff_effect_when_applied() {
+    pchar->get_equipment()->druid_bear_form_switch_to_paws();
+
+    if (sharpened_claws_bonus > 0)
+        druid->get_stats()->increase_melee_aura_crit(sharpened_claws_bonus);
+
+    if (predatory_strikes_bonus > 0)
+        druid->get_stats()->increase_melee_ap(predatory_strikes_bonus);
+
+    if (heart_of_the_wild_mod > 0)
+        druid->get_stats()->add_strength_mod(heart_of_the_wild_mod);
+
+    if (supplies_leader_of_the_pack)
+        leader_of_the_pack->apply_buff();
+
+    if (furor->is_enabled() && furor->check_proc_success())
+        furor->perform();
+
+    druid->get_stats()->increase_total_threat_mod(threat_mod);
+}
+
+void BearFormBuff::buff_effect_when_removed() {
+    pchar->get_equipment()->druid_switch_to_normal_weapon();
+
+    if (sharpened_claws_bonus > 0)
+        druid->get_stats()->decrease_melee_aura_crit(sharpened_claws_bonus);
+
+    if (predatory_strikes_bonus > 0)
+        druid->get_stats()->decrease_melee_ap(predatory_strikes_bonus);
+
+    if (heart_of_the_wild_mod > 0)
+        druid->get_stats()->remove_strength_mod(heart_of_the_wild_mod);
+
+    if (supplies_leader_of_the_pack)
+        leader_of_the_pack->cancel_buff();
+
+    druid->get_stats()->decrease_total_threat_mod(threat_mod);
+}
+
+void BearFormBuff::increase_talent_rank_effect(const QString& talent_name, const int curr) {
+    if (talent_name == "Sharpened Claws") {
+        if (is_active() && curr > 1)
+            druid->get_stats()->decrease_melee_aura_crit(sharpened_claws_bonus);
+
+        sharpened_claws_bonus = sharpened_claws_ranks[curr];
+
+        if (is_active())
+            druid->get_stats()->increase_melee_aura_crit(sharpened_claws_bonus);
+    }
+
+    if (talent_name == "Predatory Strikes") {
+        if (is_active() && curr > 1)
+            druid->get_stats()->decrease_melee_ap(predatory_strikes_bonus);
+
+        predatory_strikes_bonus = static_cast<unsigned>(std::round(pchar->get_clvl() * predatory_strikes_ranks[curr]));
+
+        if (is_active())
+            druid->get_stats()->increase_melee_ap(predatory_strikes_bonus);
+    }
+
+    if (talent_name == "Heart of the Wild") {
+        if (curr > 1) {
+            druid->get_stats()->remove_intellect_mod(heart_of_the_wild_mod);
+            if (is_active())
+                druid->get_stats()->remove_strength_mod(heart_of_the_wild_mod);
+        }
+
+        heart_of_the_wild_mod = heart_of_the_wild_str_mod_ranks[curr];
+
+        if (is_active())
+            druid->get_stats()->add_strength_mod(heart_of_the_wild_mod);
+        druid->get_stats()->add_intellect_mod(heart_of_the_wild_mod);
+    }
+
+    if (talent_name == "Leader of the Pack") {
+        supplies_leader_of_the_pack = true;
+        if (is_active())
+            leader_of_the_pack->apply_buff();
+    }
+
+    if (talent_name == "Feral Instinct") {
+        threat_mod = 30 + feral_instinct_ranks[curr];
+    }
+}
+
+void BearFormBuff::decrease_talent_rank_effect(const QString& talent_name, const int curr) {
+    if (talent_name == "Sharpened Claws") {
+        if (is_active())
+            druid->get_stats()->decrease_melee_aura_crit(sharpened_claws_bonus);
+
+        sharpened_claws_bonus = sharpened_claws_ranks[curr];
+
+        if (is_active() && sharpened_claws_bonus > 0)
+            druid->get_stats()->increase_melee_aura_crit(sharpened_claws_bonus);
+    }
+
+    if (talent_name == "Predatory Strikes") {
+        if (is_active())
+            druid->get_stats()->decrease_melee_ap(predatory_strikes_bonus);
+
+        predatory_strikes_bonus = static_cast<unsigned>(std::round(pchar->get_clvl() * predatory_strikes_ranks[curr]));
+
+        if (is_active() && predatory_strikes_bonus > 0)
+            druid->get_stats()->increase_melee_ap(predatory_strikes_bonus);
+    }
+
+    if (talent_name == "Heart of the Wild") {
+        if (is_active())
+            druid->get_stats()->remove_strength_mod(heart_of_the_wild_mod);
+        druid->get_stats()->remove_intellect_mod(heart_of_the_wild_mod);
+
+        heart_of_the_wild_mod = heart_of_the_wild_str_mod_ranks[curr];
+
+        if (heart_of_the_wild_mod > 0) {
+            druid->get_stats()->add_intellect_mod(heart_of_the_wild_mod);
+            if (is_active())
+                druid->get_stats()->add_strength_mod(heart_of_the_wild_mod);
+        }
+    }
+
+    if (talent_name == "Leader of the Pack") {
+        supplies_leader_of_the_pack = false;
+        if (is_active())
+            leader_of_the_pack->cancel_buff();
+    }
+
+    if (talent_name == "Feral Instinct") {
+        threat_mod = 30 + feral_instinct_ranks[curr];
+    }
+}

--- a/Class/Druid/Buffs/BearFormBuff.h
+++ b/Class/Druid/Buffs/BearFormBuff.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <QVector>
+
+#include "SelfBuff.h"
+#include "TalentRequirer.h"
+
+class Buff;
+class Druid;
+
+class BearFormBuff : public SelfBuff, public TalentRequirer {
+public:
+    BearFormBuff(Druid* pchar, Buff* leader_of_the_pack, Proc* furor);
+
+private:
+    Druid* druid;
+    Buff* leader_of_the_pack;
+    Proc* furor;
+    unsigned threat_mod;
+
+    void buff_effect_when_applied() override;
+    void buff_effect_when_removed() override;
+
+    unsigned sharpened_claws_bonus {0};
+    const QVector<unsigned> sharpened_claws_ranks {0, 200, 400, 600};
+
+    const QVector<unsigned> feral_instinct_ranks {0, 3, 6, 9, 12, 15};
+
+    unsigned predatory_strikes_bonus {0};
+    const QVector<double> predatory_strikes_ranks {0, 0.5, 1.0, 1.5};
+
+    int heart_of_the_wild_mod {0};
+    const QVector<int> heart_of_the_wild_str_mod_ranks {0, 4, 8, 12, 16, 20};
+
+    bool supplies_leader_of_the_pack {false};
+
+    void increase_talent_rank_effect(const QString& talent_name, const int curr) override;
+    void decrease_talent_rank_effect(const QString& talent_name, const int curr) override;
+};

--- a/Class/Druid/Druid.cpp
+++ b/Class/Druid/Druid.cpp
@@ -85,7 +85,16 @@ unsigned Druid::get_melee_ap_per_strength() const {
 }
 
 unsigned Druid::get_melee_ap_per_agi() const {
-    return 1;
+    switch (current_form) {
+    case DruidForm::Caster:
+    case DruidForm::Bear:
+    case DruidForm::Moonkin:
+        return 0;
+    case DruidForm::Cat:
+        return 1;
+    }
+    check(false, "Reached end of Druid::get_melee_ap_per_agi() switch");
+    return 0;
 }
 
 unsigned Druid::get_ranged_ap_per_agi() const {
@@ -226,6 +235,8 @@ void Druid::switch_to_form(const DruidForm new_form) {
     cancel_form();
     druid_spells->get_caster_form()->buff->cancel_buff();
 
+    this->current_form = new_form;
+
     switch (new_form) {
     case DruidForm::Bear:
         druid_spells->get_bear_form()->buff->apply_buff();
@@ -240,7 +251,6 @@ void Druid::switch_to_form(const DruidForm new_form) {
         check(false, "Unhandled form in Druid::switch_to_form()");
     }
 
-    this->current_form = new_form;
     this->next_form_cd = engine->get_current_priority() + form_cooldown();
 
     if ((engine->get_current_priority() + 0.5) > this->next_gcd) {

--- a/Class/Druid/DruidSpells.cpp
+++ b/Class/Druid/DruidSpells.cpp
@@ -1,36 +1,42 @@
 #include "DruidSpells.h"
 
 #include "BearForm.h"
+#include "BearFormBuff.h"
 #include "BloodFrenzy.h"
 #include "CasterForm.h"
 #include "CatForm.h"
 #include "CatFormBuff.h"
+#include "CharacterSpells.h"
 #include "ClearcastingDruid.h"
 #include "Druid.h"
+#include "Enrage.h"
 #include "FerociousBite.h"
 #include "Furor.h"
 #include "LeaderOfThePack.h"
 #include "MainhandAttackDruid.h"
+#include "Maul.h"
 #include "Moonfire.h"
 #include "MoonkinForm.h"
 #include "MoonkinFormBuff.h"
 #include "NaturesGrace.h"
+#include "NoEffectSelfBuff.h"
+#include "PrimalFury.h"
 #include "RaidControl.h"
 #include "Shred.h"
+#include "SpellRankGroup.h"
 #include "Starfire.h"
+#include "Swipe.h"
 #include "TigersFury.h"
 #include "TigersFuryBuff.h"
 #include "Wrath.h"
 
 DruidSpells::DruidSpells(Druid* druid) : CharacterSpells(druid), druid(druid) {
-    this->mh_attack = new MainhandAttackDruid(druid);
+    this->primal_fury = new PrimalFury(druid);
+    this->mh_attack = new MainhandAttackDruid(druid, primal_fury);
     add_spell_group({mh_attack});
 
     this->caster_form = new CasterForm(druid);
     add_spell_group({caster_form});
-
-    this->bear_form = new BearForm(druid);
-    add_spell_group({bear_form});
 
     auto leader_of_the_pack = static_cast<LeaderOfThePack*>(
         pchar->get_raid_control()->get_shared_party_buff("Leader of the Pack", pchar->get_party()));
@@ -38,7 +44,12 @@ DruidSpells::DruidSpells(Druid* druid) : CharacterSpells(druid), druid(druid) {
         leader_of_the_pack = new LeaderOfThePack(druid);
         leader_of_the_pack->enable_buff();
     }
+
     this->furor = new Furor(druid);
+    this->bear_form_buff = new BearFormBuff(druid, leader_of_the_pack, furor);
+    this->bear_form = new BearForm(druid, bear_form_buff);
+    add_spell_group({bear_form});
+
     this->cat_form_buff = new CatFormBuff(druid, leader_of_the_pack, furor);
     this->cat_form = new CatForm(druid, cat_form_buff);
     add_spell_group({cat_form});
@@ -92,12 +103,34 @@ DruidSpells::DruidSpells(Druid* druid) : CharacterSpells(druid), druid(druid) {
     });
 
     add_spell_group({
+        new Swipe(druid, this, primal_fury, 1),
+        new Swipe(druid, this, primal_fury, 2),
+        new Swipe(druid, this, primal_fury, 3),
+        new Swipe(druid, this, primal_fury, 4),
+        new Swipe(druid, this, primal_fury, 5),
+    });
+
+    this->maul_buff = new NoEffectSelfBuff(druid, BuffDuration::PERMANENT, "Maul Queued", "Assets/ability/Ability_rogue_ambush.png", Hidden::No);
+    this->maul_buff->enable_buff();
+    add_spell_group({
+        new Maul(druid, this, maul_buff, 1),
+        new Maul(druid, this, maul_buff, 2),
+        new Maul(druid, this, maul_buff, 3),
+        new Maul(druid, this, maul_buff, 4),
+        new Maul(druid, this, maul_buff, 5),
+        new Maul(druid, this, maul_buff, 6),
+        new Maul(druid, this, maul_buff, 7),
+    });
+
+    add_spell_group({
         new FerociousBite(druid, 1),
         new FerociousBite(druid, 2),
         new FerociousBite(druid, 3),
         new FerociousBite(druid, 4),
         new FerociousBite(druid, 5),
     });
+
+    add_spell_group({new Enrage(druid)});
 
     tigers_fury_buff = new TigersFuryBuff(pchar);
     tigers_fury_buff->enable_buff();
@@ -116,9 +149,35 @@ DruidSpells::~DruidSpells() {
     delete natures_grace;
     delete omen_of_clarity;
     delete cat_form_buff;
+    delete bear_form_buff;
     delete blood_frenzy;
     delete furor;
     delete tigers_fury_buff;
+    delete maul_buff;
+}
+
+void DruidSpells::mh_auto_attack(const int iteration) {
+    if (!mh_attack->attack_is_valid(iteration))
+        return;
+
+    if (!is_melee_attacking())
+        return;
+
+    if (maul->is_queued() && maul->get_spell_status() == SpellStatus::Available) {
+        maul->calculate_damage();
+    } else {
+        if (maul->is_queued())
+            maul->cancel();
+
+        mh_attack->perform();
+    }
+
+    add_next_mh_attack();
+}
+
+void DruidSpells::prepare_set_of_combat_iterations_class_specific() {
+    SpellRankGroup* group = get_spell_rank_group_by_name("Maul");
+    maul = static_cast<Maul*>(group->get_max_available_spell_rank());
 }
 
 CasterForm* DruidSpells::get_caster_form() const {
@@ -145,12 +204,20 @@ Buff* DruidSpells::get_cat_form_buff() const {
     return this->cat_form_buff;
 }
 
+Buff* DruidSpells::get_bear_form_buff() const {
+    return this->bear_form_buff;
+}
+
 Proc* DruidSpells::get_omen_of_clarity() const {
     return this->omen_of_clarity;
 }
 
 Proc* DruidSpells::get_blood_frenzy() const {
     return this->blood_frenzy;
+}
+
+Proc* DruidSpells::get_primal_fury() const {
+    return this->primal_fury;
 }
 
 Proc* DruidSpells::get_furor() const {

--- a/Class/Druid/DruidSpells.h
+++ b/Class/Druid/DruidSpells.h
@@ -11,11 +11,15 @@ class Druid;
 class MoonkinForm;
 class Proc;
 class TigersFuryBuff;
+class MainhandAttackDruid;
+class Maul;
 
 class DruidSpells : public CharacterSpells {
 public:
     DruidSpells(Druid* druid);
     ~DruidSpells() override;
+
+    void mh_auto_attack(const int iteration) override;
 
     CasterForm* get_caster_form() const;
     BearForm* get_bear_form() const;
@@ -23,8 +27,10 @@ public:
     MoonkinForm* get_moonkin_form() const;
     Buff* get_natures_grace() const;
     Buff* get_cat_form_buff() const;
+    Buff* get_bear_form_buff() const;
     Proc* get_omen_of_clarity() const;
     Proc* get_blood_frenzy() const;
+    Proc* get_primal_fury() const;
     Proc* get_furor() const;
 
     bool omen_of_clarity_active() const;
@@ -38,8 +44,15 @@ private:
     MoonkinForm* moonkin_form;
     Buff* natures_grace;
     Buff* cat_form_buff;
+    Buff* bear_form_buff;
+    Buff* maul_buff;
     TigersFuryBuff* tigers_fury_buff;
     ClearcastingDruid* omen_of_clarity;
     Proc* blood_frenzy;
+    Proc* primal_fury;
     Proc* furor;
+
+    Maul* maul;
+
+    void prepare_set_of_combat_iterations_class_specific() override;
 };

--- a/Class/Druid/Procs/Furor.cpp
+++ b/Class/Druid/Procs/Furor.cpp
@@ -4,6 +4,7 @@
 #include "Druid.h"
 #include "ProcInfo.h"
 #include "StatisticsResource.h"
+#include "Utils/Check.h"
 
 Furor::Furor(Druid* druid) :
     Proc("Furor",
@@ -22,12 +23,23 @@ Furor::Furor(Druid* druid) :
 }
 
 void Furor::proc_effect() {
-    const unsigned before_gain = druid->get_resource_level(ResourceType::Energy);
+    if (druid->get_current_form() == DruidForm::Cat) {
+        const unsigned before_gain = druid->get_resource_level(ResourceType::Energy);
 
-    druid->gain_energy(40);
+        druid->gain_energy(40);
 
-    const unsigned delta = druid->get_resource_level(ResourceType::Energy) - before_gain;
-    statistics_resource->add_resource_gain(ResourceType::Energy, delta);
+        const unsigned delta = druid->get_resource_level(ResourceType::Energy) - before_gain;
+        statistics_resource->add_resource_gain(ResourceType::Energy, delta);
+    } else if (druid->get_current_form() == DruidForm::Bear) {
+        const unsigned before_gain = druid->get_resource_level(ResourceType::Rage);
+
+        druid->gain_rage(10);
+
+        const unsigned delta = druid->get_resource_level(ResourceType::Rage) - before_gain;
+        statistics_resource->add_resource_gain(ResourceType::Rage, delta);
+    } else {
+        check(false, std::string("Furor::proc_effect called in invalid form "));
+    }
 }
 
 void Furor::increase_talent_rank_effect(const QString&, const int curr) {

--- a/Class/Druid/Procs/PrimalFury.cpp
+++ b/Class/Druid/Procs/PrimalFury.cpp
@@ -1,0 +1,31 @@
+#include "PrimalFury.h"
+
+#include "Druid.h"
+#include "ProcInfo.h"
+
+PrimalFury::PrimalFury(Druid* druid) :
+    Proc("Primal Fury",
+         "Assets/ability/Ability_ghoulfrenzy.png",
+         0.0,
+         0,
+         QVector<Proc*>(),
+         QVector<ProcInfo::Source>({ProcInfo::Source::Manual}),
+         druid),
+    TalentRequirer(QVector<TalentRequirerInfo*> {new TalentRequirerInfo("Primal Fury", 2, DisabledAtZero::Yes)}),
+    druid(druid),
+    talent_ranks({0, 5000, 10000}) {
+    this->enabled = false;
+    proc_range = talent_ranks[0];
+}
+
+void PrimalFury::proc_effect() {
+    druid->gain_rage(5);
+}
+
+void PrimalFury::increase_talent_rank_effect(const QString&, const int curr) {
+    proc_range = talent_ranks[curr];
+}
+
+void PrimalFury::decrease_talent_rank_effect(const QString&, const int curr) {
+    proc_range = talent_ranks[curr];
+}

--- a/Class/Druid/Procs/PrimalFury.h
+++ b/Class/Druid/Procs/PrimalFury.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Proc.h"
+#include "TalentRequirer.h"
+
+class Druid;
+
+class PrimalFury : public Proc, public TalentRequirer {
+public:
+    PrimalFury(Druid* druid);
+    void proc_effect() override;
+
+private:
+    Druid* druid;
+    const QVector<unsigned> talent_ranks;
+
+    void increase_talent_rank_effect(const QString& talent_name, const int curr) override;
+    void decrease_talent_rank_effect(const QString& talent_name, const int curr) override;
+};

--- a/Class/Druid/Spells/BearForm.cpp
+++ b/Class/Druid/Spells/BearForm.cpp
@@ -6,7 +6,7 @@
 #include "Druid.h"
 #include "NoEffectSelfBuff.h"
 
-BearForm::BearForm(Druid* druid) :
+BearForm::BearForm(Druid* druid, Buff* bear_form) :
     Spell("Bear Form",
           "Assets/ability/Ability_racial_bearform.png",
           druid,
@@ -14,16 +14,18 @@ BearForm::BearForm(Druid* druid) :
           RestrictedByGcd::No,
           ResourceType::Mana,
           100),
-    TalentRequirer({new TalentRequirerInfo("Natural Shapeshifter", 3, DisabledAtZero::No)}),
+    TalentRequirer({
+        new TalentRequirerInfo("Natural Shapeshifter", 3, DisabledAtZero::No),
+        new TalentRequirerInfo("Sharpened Claws", 3, DisabledAtZero::No),
+    }),
     druid(druid),
-    buff(new NoEffectSelfBuff(druid, BuffDuration::PERMANENT, "Bear Form", icon, Hidden::No)),
+    buff(bear_form),
     base_resource_cost(resource_cost) {
     buff->enable_buff();
 }
 
 BearForm::~BearForm() {
     delete cooldown;
-    delete buff;
 }
 
 SpellStatus BearForm::is_ready_spell_specific() const {

--- a/Class/Druid/Spells/BearForm.h
+++ b/Class/Druid/Spells/BearForm.h
@@ -8,7 +8,7 @@ class Druid;
 
 class BearForm : public Spell, public TalentRequirer {
 public:
-    BearForm(Druid* druid);
+    BearForm(Druid* druid, Buff* buff);
     ~BearForm() override;
 
 private:

--- a/Class/Druid/Spells/Enrage.cpp
+++ b/Class/Druid/Spells/Enrage.cpp
@@ -1,0 +1,69 @@
+#include "Enrage.h"
+
+#include "Buff.h"
+#include "ClassStatistics.h"
+#include "CooldownControl.h"
+#include "Engine.h"
+#include "StatisticsResource.h"
+#include "Druid.h"
+#include "Utils/Check.h"
+
+Enrage::Enrage(Druid* druid) :
+    PeriodicResourceGainSpell("Enrage",
+                              "Assets/ability/Ability_druid_enrage.png",
+                              druid,
+                              RestrictedByGcd::No,
+                              1.0,
+                              10,
+                              {{ResourceType::Rage, 2}}),
+    TalentRequirer(QVector<TalentRequirerInfo*> {new TalentRequirerInfo("Improved Enrage", 2, DisabledAtZero::No)}),
+    drood(druid) {
+    delete cooldown;
+    cooldown = new CooldownControl(druid, 60.0);
+    enabled = true;
+    marker_buff->enable_buff();
+}
+
+void Enrage::new_application_effect() {
+    cooldown->add_spell_cd_event();
+
+    gain_rage(immediate_rage_gain);
+}
+
+SpellStatus Enrage::is_ready_spell_specific() const {
+    if (drood->get_current_form() == DruidForm::Bear)
+        return SpellStatus::Available;
+
+    switch (drood->get_current_form()) {
+    case DruidForm::Cat:
+        return SpellStatus::InCatForm;
+    case DruidForm::Caster:
+        return SpellStatus::InCasterForm;
+    case DruidForm::Moonkin:
+        return SpellStatus::InMoonkinForm;
+    default:
+        check(false, "Reached end of switch in Shred::is_ready_spell_specific()");
+        return SpellStatus::NotEnabled;
+    }
+}
+
+void Enrage::increase_talent_rank_effect(const QString& talent_name, const int curr) {
+    if (talent_name == "Improved Enrage")
+        this->immediate_rage_gain = talent_ranks[curr];
+}
+
+void Enrage::decrease_talent_rank_effect(const QString& talent_name, const int curr) {
+    if (talent_name == "Improved Enrage")
+        this->immediate_rage_gain = talent_ranks[curr];
+}
+
+void Enrage::gain_rage(const unsigned rage_gain) {
+    const unsigned before = drood->get_resource_level(ResourceType::Rage);
+
+    drood->gain_rage(rage_gain);
+
+    const unsigned gain_after_cap = drood->get_resource_level(ResourceType::Rage) - before;
+
+    if (gain_after_cap > 0)
+        statistics_resource->add_resource_gain(ResourceType::Rage, gain_after_cap);
+}

--- a/Class/Druid/Spells/Enrage.h
+++ b/Class/Druid/Spells/Enrage.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "PeriodicResourceGainSpell.h"
+#include "TalentRequirer.h"
+
+class Druid;
+
+class Enrage : public PeriodicResourceGainSpell, public TalentRequirer {
+public:
+    Enrage(Druid* druid);
+
+private:
+    friend class ImprovedEnrage;
+
+    Druid* drood;
+
+    QVector<unsigned> talent_ranks {0, 5, 10};
+    unsigned immediate_rage_gain {0};
+    const unsigned periodic_rage_base {20};
+    unsigned periodic_rage_current {20};
+
+    void new_application_effect() override;
+    SpellStatus is_ready_spell_specific() const override;
+
+    void increase_talent_rank_effect(const QString& talent_name, const int curr) override;
+    void decrease_talent_rank_effect(const QString& talent_name, const int curr) override;
+
+    void gain_rage(const unsigned rage_gain);
+};

--- a/Class/Druid/Spells/MainhandAttackDruid.cpp
+++ b/Class/Druid/Spells/MainhandAttackDruid.cpp
@@ -8,12 +8,13 @@
 #include "Druid.h"
 #include "Equipment.h"
 #include "Flurry.h"
+#include "PrimalFury.h"
 #include "RecklessnessBuff.h"
 #include "StatisticsResource.h"
 #include "Utils/Check.h"
 #include "Weapon.h"
 
-MainhandAttackDruid::MainhandAttackDruid(Druid* pchar) : MainhandAttack(pchar), druid(pchar) {}
+MainhandAttackDruid::MainhandAttackDruid(Druid* pchar, Proc* primal_fury) : MainhandAttack(pchar), druid(pchar), primal_fury(primal_fury) {}
 
 void MainhandAttackDruid::calculate_damage() {
     const unsigned mh_wpn_skill = get_weapon_skill();
@@ -52,8 +53,11 @@ void MainhandAttackDruid::calculate_damage() {
         add_crit_dmg(static_cast<int>(damage_dealt), resource_cost, 0);
         druid->melee_mh_white_critical_effect();
 
-        if (druid->get_current_form() == DruidForm::Bear)
+        if (druid->get_current_form() == DruidForm::Bear) {
             gain_rage(damage_dealt);
+            if (primal_fury->is_enabled() && primal_fury->check_proc_success())
+                primal_fury->perform();
+        }
 
         return;
     }
@@ -73,17 +77,18 @@ void MainhandAttackDruid::calculate_damage() {
     damage_dealt = round(damage_dealt);
     add_hit_dmg(static_cast<int>(damage_dealt), resource_cost, 0);
 
-    if (druid->get_current_form() == DruidForm::Bear)
+    if (druid->get_current_form() == DruidForm::Bear) {
         gain_rage(damage_dealt);
+    }
 }
 
 void MainhandAttackDruid::prepare_set_of_combat_iterations_spell_specific() {
+    this->statistics_resource = pchar->get_statistics()->get_resource_statistics(name, icon);
     if (pchar->get_equipment()->get_mainhand() == nullptr)
         return;
 
     this->icon = "Assets/items/" + pchar->get_equipment()->get_mainhand()->get_value("icon");
     this->cooldown->base = pchar->get_stats()->get_mh_wpn_speed();
-    this->statistics_resource = pchar->get_statistics()->get_resource_statistics(name, icon);
 
     reset();
 }

--- a/Class/Druid/Spells/MainhandAttackDruid.h
+++ b/Class/Druid/Spells/MainhandAttackDruid.h
@@ -4,14 +4,16 @@
 
 class StatisticsResource;
 class Druid;
+class Proc;
 
 class MainhandAttackDruid : public MainhandAttack {
 public:
-    MainhandAttackDruid(Druid* pchar);
+    MainhandAttackDruid(Druid* pchar, Proc* primal_fury);
 
 private:
     Druid* druid;
     StatisticsResource* statistics_resource {nullptr};
+    Proc* primal_fury;
 
     void calculate_damage() override;
     void prepare_set_of_combat_iterations_spell_specific() override;

--- a/Class/Druid/Spells/Maul.cpp
+++ b/Class/Druid/Spells/Maul.cpp
@@ -1,0 +1,155 @@
+#include "Maul.h"
+
+#include "Buff.h"
+#include "CharacterStats.h"
+#include "CombatRoll.h"
+#include "CooldownControl.h"
+#include "Druid.h"
+#include "DruidSpells.h"
+#include "MainhandAttackDruid.h"
+#include "NoEffectSelfBuff.h"
+#include "SimSettings.h"
+
+Maul::Maul(Druid* druid, DruidSpells* spells, Buff* maul_buff, const int rank_spell) :
+    Spell("Maul",
+          "Assets/ability/Ability_druid_maul.png",
+          druid,
+          new CooldownControl(druid, 0.0),
+          RestrictedByGcd::No,
+          ResourceType::Rage,
+          15,
+          rank_spell),
+    TalentRequirer(QVector<TalentRequirerInfo*> {
+        new TalentRequirerInfo("Ferocity", 5, DisabledAtZero::No),
+        new TalentRequirerInfo("Savage Fury", 2, DisabledAtZero::No),
+    }),
+    drood(druid),
+    spells(spells),
+    maul_buff(maul_buff) {
+    damage_mod = 1.0;
+    switch (spell_rank) {
+    case 1:
+        additional_dmg = 18;
+        level_req = 10;
+        break;
+    case 2:
+        additional_dmg = 27;
+        level_req = 18;
+        break;
+    case 3:
+        additional_dmg = 37;
+        level_req = 26;
+        break;
+    case 4:
+        additional_dmg = 49;
+        level_req = 34;
+        break;
+    case 5:
+        additional_dmg = 71;
+        level_req = 42;
+        break;
+    case 6:
+        additional_dmg = 101;
+        level_req = 50;
+        break;
+    case 7:
+        additional_dmg = 128;
+        level_req = 58;
+        break;
+    default:
+        check(false, QString("%1 does not support rank %2").arg(name).arg(spell_rank).toStdString());
+    }
+}
+
+SpellStatus Maul::is_ready_spell_specific() const {
+    if (drood->get_current_form() == DruidForm::Bear)
+        return SpellStatus::Available;
+
+    switch (drood->get_current_form()) {
+    case DruidForm::Cat:
+        return SpellStatus::InCatForm;
+    case DruidForm::Caster:
+        return SpellStatus::InCasterForm;
+    case DruidForm::Moonkin:
+        return SpellStatus::InMoonkinForm;
+    default:
+        check(false, "Reached end of switch in Shred::is_ready_spell_specific()");
+        return SpellStatus::NotEnabled;
+    }
+}
+
+Maul::~Maul() {
+    delete cooldown;
+}
+
+bool Maul::is_rank_learned() const {
+    if (spell_rank >= 1 && spell_rank <= 7)
+        return pchar->get_clvl() >= level_req;
+
+    check(false, QString("%1::is_rank_learned() failed for rank %2").arg(name).arg(spell_rank).toStdString());
+    return false;
+}
+
+bool Maul::is_queued() const {
+    return maul_buff->is_active();
+}
+
+void Maul::cancel() {
+    maul_buff->cancel_buff();
+}
+
+void Maul::calculate_damage() {
+    drood->get_spells()->get_mh_attack()->complete_swing();
+
+    const int result = roll->get_melee_ability_result(drood->get_mh_wpn_skill(), pchar->get_stats()->get_mh_crit_chance());
+
+    cancel();
+
+    if (result == PhysicalAttackResult::MISS) {
+        increment_miss();
+        drood->lose_rage(resource_cost);
+        return;
+    }
+    if (result == PhysicalAttackResult::DODGE) {
+        increment_dodge();
+        drood->lose_rage(static_cast<unsigned>(round(resource_cost * 0.25)));
+        return;
+    }
+    if (result == PhysicalAttackResult::PARRY) {
+        increment_parry();
+        drood->lose_rage(static_cast<unsigned>(round(resource_cost * 0.25)));
+        return;
+    }
+
+    drood->lose_rage(resource_cost);
+
+    double damage_dealt = damage_mod * damage_after_modifiers(drood->get_random_non_normalized_mh_dmg() + additional_dmg);
+
+    if (result == PhysicalAttackResult::CRITICAL) {
+        drood->melee_mh_yellow_critical_effect();
+        double crit_damage_dealt = damage_dealt * drood->get_stats()->get_melee_ability_crit_dmg_mod();
+        add_crit_dmg(static_cast<int>(round(crit_damage_dealt)), resource_cost, 0, round(crit_damage_dealt * 0.75));
+    } else if (result == PhysicalAttackResult::HIT) {
+        drood->melee_mh_yellow_hit_effect();
+        add_hit_dmg(static_cast<int>(round(damage_dealt)), resource_cost, 0, round(damage_dealt * 0.75));
+    }
+}
+
+void Maul::spell_effect() {
+    maul_buff->apply_buff();
+    is_queued();
+}
+
+void Maul::increase_talent_rank_effect(const QString& talent_name, const int curr) {
+    if (talent_name == "Ferocity")
+        resource_cost = ferocity_ranks[curr];
+    else if (talent_name == "Savage Fury")
+        damage_mod = 1 + (curr * 0.1);
+}
+
+void Maul::decrease_talent_rank_effect(const QString& talent_name, const int curr) {
+    if (talent_name == "Ferocity")
+        resource_cost = ferocity_ranks[curr];
+    else if (talent_name == "Savage Fury")
+        damage_mod = 1 + (curr * 0.1);
+}

--- a/Class/Druid/Spells/Maul.h
+++ b/Class/Druid/Spells/Maul.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Spell.h"
+#include "TalentRequirer.h"
+
+class Buff;
+class Druid;
+class DruidSpells;
+
+class Maul : public Spell, public TalentRequirer {
+public:
+    Maul(Druid* druid, DruidSpells* spells, Buff* maul_buff, const int spell_rank);
+    ~Maul() override;
+
+    bool is_queued() const;
+    void cancel();
+    void calculate_damage();
+
+    bool is_rank_learned() const override;
+
+private:
+    Druid* drood;
+    DruidSpells* spells;
+    Buff* maul_buff;
+    unsigned additional_dmg;
+    double damage_mod;
+
+    const QVector<unsigned> ferocity_ranks {15, 14, 13, 12, 11, 10};
+
+    void spell_effect() override;
+    SpellStatus is_ready_spell_specific() const override;
+
+    void increase_talent_rank_effect(const QString& talent_name, const int curr) override;
+    void decrease_talent_rank_effect(const QString& talent_name, const int curr) override;
+};

--- a/Class/Druid/Spells/Swipe.cpp
+++ b/Class/Druid/Spells/Swipe.cpp
@@ -1,0 +1,131 @@
+#include "Swipe.h"
+
+#include "Buff.h"
+#include "CharacterSpells.h"
+#include "CharacterStats.h"
+#include "CombatRoll.h"
+#include "CooldownControl.h"
+#include "Druid.h"
+#include "DruidSpells.h"
+#include "Proc.h"
+#include "SimSettings.h"
+#include "Utils/Check.h"
+
+Swipe::Swipe(Druid* pchar, DruidSpells* druid_spells, Proc* primal_fury, const int spell_rank) :
+    Spell("Swipe",
+          "Assets/ability/Ability_druid_swipe.png",
+          pchar,
+          new CooldownControl(pchar, 0.0),
+          RestrictedByGcd::Yes,
+          ResourceType::Rage,
+          20,
+          spell_rank),
+    TalentRequirer(QVector<TalentRequirerInfo*> {
+        new TalentRequirerInfo("Ferocity", 5, DisabledAtZero::No),
+        new TalentRequirerInfo("Savage Fury", 2, DisabledAtZero::No),
+    }),
+    druid(pchar),
+    druid_spells(druid_spells),
+    primal_fury(primal_fury) {
+    damage_mod = 1.0;
+    switch (spell_rank) {
+    case 1:
+        bonus_damage = 18;
+        level_req = 16;
+        break;
+    case 2:
+        bonus_damage = 25;
+        level_req = 24;
+        break;
+    case 3:
+        bonus_damage = 36;
+        level_req = 34;
+        break;
+    case 4:
+        bonus_damage = 60;
+        level_req = 44;
+        break;
+    case 5:
+        bonus_damage = 83;
+        level_req = 54;
+        break;
+    default:
+        check(false, QString("%1 does not support rank %2").arg(name).arg(spell_rank).toStdString());
+    }
+}
+
+Swipe::~Swipe() {
+    delete cooldown;
+}
+
+bool Swipe::is_rank_learned() const {
+    return pchar->get_clvl() >= level_req;
+}
+
+void Swipe::spell_effect() {
+    druid->exit_stealth();
+
+    const int result = roll->get_melee_ability_result(druid->get_mh_wpn_skill(), pchar->get_stats()->get_mh_crit_chance());
+
+    cooldown->add_gcd_event();
+
+    if (result == PhysicalAttackResult::MISS) {
+        increment_miss();
+        return;
+    }
+    if (result == PhysicalAttackResult::DODGE) {
+        increment_dodge();
+        return;
+    }
+    if (result == PhysicalAttackResult::PARRY) {
+        increment_parry();
+        return;
+    }
+
+    druid->lose_rage(resource_cost);
+
+    double damage_dealt = damage_mod * damage_after_modifiers(bonus_damage);
+
+    if (result == PhysicalAttackResult::CRITICAL) {
+        damage_dealt = round(damage_dealt * druid->get_stats()->get_melee_ability_crit_dmg_mod());
+        druid->melee_mh_yellow_critical_effect();
+        add_crit_dmg(static_cast<int>(round(damage_dealt)), resource_cost, pchar->global_cooldown(), round(damage_dealt * 0.75));
+
+        if (primal_fury->is_enabled() && primal_fury->check_proc_success())
+            primal_fury->perform();
+    } else if (result == PhysicalAttackResult::HIT) {
+        druid->melee_mh_yellow_hit_effect();
+        add_hit_dmg(static_cast<int>(round(damage_dealt)), resource_cost, pchar->global_cooldown(), round(damage_dealt * 0.75));
+    }
+}
+
+SpellStatus Swipe::is_ready_spell_specific() const {
+    if (druid->get_current_form() == DruidForm::Bear)
+        return SpellStatus::Available;
+
+    switch (druid->get_current_form()) {
+    case DruidForm::Cat:
+        return SpellStatus::InCatForm;
+    case DruidForm::Caster:
+        return SpellStatus::InCasterForm;
+    case DruidForm::Moonkin:
+        return SpellStatus::InMoonkinForm;
+    default:
+        check(false, "Reached end of switch in Swipe::is_ready_spell_specific()");
+        return SpellStatus::NotEnabled;
+    }
+}
+
+void Swipe::increase_talent_rank_effect(const QString& talent_name, const int curr) {
+    if (talent_name == "Ferocity")
+        resource_cost = base_resource_cost - ferocity_ranks[curr];
+    else if (talent_name == "Savage Fury")
+        damage_mod = 1 + (curr * 0.1);
+}
+
+void Swipe::decrease_talent_rank_effect(const QString& talent_name, const int curr) {
+    if (talent_name == "Ferocity")
+        increase_talent_rank_effect(talent_name, curr);
+    else if (talent_name == "Savage Fury")
+        damage_mod = 1 + (curr * 0.1);
+}

--- a/Class/Druid/Spells/Swipe.h
+++ b/Class/Druid/Spells/Swipe.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QVector>
+
+#include "Spell.h"
+#include "TalentRequirer.h"
+
+class Druid;
+class DruidSpells;
+class Proc;
+
+class Swipe : public Spell, public TalentRequirer {
+public:
+    Swipe(Druid* pchar, DruidSpells* druid_spells, Proc* blood_frenzy, const int spell_rank);
+    ~Swipe() override;
+
+    bool is_rank_learned() const override;
+
+private:
+    Druid* druid;
+    DruidSpells* druid_spells;
+    Proc* primal_fury;
+
+    const unsigned base_resource_cost {20};
+    unsigned bonus_damage;
+    double damage_mod;
+
+    const QVector<unsigned> ferocity_ranks {0, 1, 2, 3, 4, 5};
+
+    void spell_effect() override;
+    SpellStatus is_ready_spell_specific() const override;
+
+    void increase_talent_rank_effect(const QString& talent_name, const int curr) override;
+    void decrease_talent_rank_effect(const QString& talent_name, const int curr) override;
+};

--- a/Class/Druid/TalentTrees/FeralCombat.cpp
+++ b/Class/Druid/TalentTrees/FeralCombat.cpp
@@ -13,24 +13,18 @@ FeralCombat::FeralCombat(Druid* druid) :
         {"Savage Fury", "5LL"},    {"Faerie Fire (Feral)", "5MR"}, {"Heart of the Wild", "6ML"}, {"Leader of the Pack", "7ML"},
     };
 
-    QMap<QString, Talent*> tier1 {
-        {"1ML", new Talent(druid, this, "Ferocity", "1ML", "Assets/ability/Ability_hunter_pet_hyena.png", 5,
-                           "Reduces the cost of your Maul, Swipe, Claw, and Rake abilities by %1 Rage or Energy.",
-                           QVector<QPair<unsigned, unsigned>> {{1, 1}})},
-    };
+    QMap<QString, Talent*> tier1;
+    add_ferocity(tier1);
     add_feral_aggression(tier1);
     add_talents(tier1);
 
     QMap<QString, Talent*> tier2 {
-        {"2LL",
-         new Talent(druid, this, "Feral Instinct", "2LL", "Assets/ability/Ability_ambush.png", 5,
-                    "Increases threat caused in Bear and Dire Bear Form by %1% and reduces the chance enemies have to detect you while Prowling.",
-                    QVector<QPair<unsigned, unsigned>> {{3, 3}})},
         {"2ML", new Talent(druid, this, "Brutal Impact", "2ML", "Assets/ability/Ability_druid_bash.png", 2,
                            "Increases the stun duration of your Bash and Pounce abilities by %1 sec.", QVector<QPair<double, double>> {{0.5, 0.5}})},
         {"2MR", new Talent(druid, this, "Thick Hide", "2MR", "Assets/items/Inv_misc_pelt_bear_03.png", 5,
                            "Increases your Armor contribution from items by %1%.", QVector<QPair<unsigned, unsigned>> {{2, 2}})},
     };
+    add_feral_instinct(tier2);
     add_talents(tier2);
 
     QMap<QString, Talent*> tier3 {
@@ -45,24 +39,19 @@ FeralCombat::FeralCombat(Druid* druid) :
     add_sharpened_claws(tier3);
     add_talents(tier3);
 
-    QMap<QString, Talent*> tier4 {
-        {"4RR", new Talent(druid, this, "Primal Fury", "4RR", "Assets/ability/Ability_racial_cannibalize.png", 2,
-                           "Gives you a %1% chance to gain an additional 5 Rage anytime you get a critical strike while in Bear and Dire Bear Form.",
-                           QVector<QPair<unsigned, unsigned>> {{50, 50}})},
-    };
+    QMap<QString, Talent*> tier4;
+    add_primal_fury(tier4);
     add_improved_shred(tier4);
     add_predatory_strikes(tier4);
     add_blood_frenzy(tier4);
     add_talents(tier4);
 
     QMap<QString, Talent*> tier5 {
-        {"5LL", new Talent(druid, this, "Savage Fury", "5LL", "Assets/ability/Ability_druid_ravage.png", 2,
-                           "Increases the damage caused by your Claw, Rake, Maul and Swipe abilities by %1%.",
-                           QVector<QPair<unsigned, unsigned>> {{10, 10}})},
         {"5MR", new Talent(druid, this, "Faerie Fire (Feral)", "5MR", "Assets/spell/Spell_nature_faeriefire.png", 1,
                            "Decrease the armor of the target by 175 for 40 sec. While affected, the target cannot stealth or turn invisible.",
                            QVector<QPair<unsigned, unsigned>>())},
     };
+    add_savage_fury(tier5);
     add_talents(tier5);
 
     QMap<QString, Talent*> tier6 {};
@@ -82,6 +71,43 @@ FeralCombat::FeralCombat(Druid* druid) :
     talents["6ML"]->talent->set_parent(talents["4ML"]->talent);
 }
 
+void FeralCombat::add_feral_instinct(QMap<QString, Talent*>& talent_tier) {
+    Talent* talent
+        = get_new_talent(druid, "Feral Instinct", "2LL", "Assets/ability/Ability_ambush.png", 5,
+                     "Increases threat caused in Bear and Dire Bear Form by %1% and reduces the chance enemies have to detect you while Prowling.",
+                         QVector<QPair<unsigned, unsigned>> {{3, 3}}, {}, QVector<Buff*> {spells->get_bear_form_buff()});
+
+    add_talent_to_tier(talent_tier, talent);
+}
+
+void FeralCombat::add_savage_fury(QMap<QString, Talent*>& talent_tier) {
+    Talent* talent
+        = get_new_talent(druid, "Savage Fury", "5LL", "Assets/ability/Ability_druid_ravage.png", 2,
+                     "Increases the damage caused by your Claw, Rake, Maul and Swipe abilities by %1%.",
+                         QVector<QPair<unsigned, unsigned>> {{10, 10}}, QVector<SpellRankGroup*> {spells->get_spell_rank_group_by_name("Maul"), spells->get_spell_rank_group_by_name("Swipe")});
+
+    add_talent_to_tier(talent_tier, talent);
+}
+
+void FeralCombat::add_primal_fury(QMap<QString, Talent*>& talent_tier) {
+    Talent* talent
+        = get_new_talent(druid, "Primal Fury", "4RR", "Assets/ability/Ability_racial_cannibalize.png", 2,
+                     "Gives you a %1% chance to gain an additional 5 Rage anytime you get a critical strike while in Bear and Dire Bear Form.",
+                     QVector<QPair<unsigned, unsigned>> {{50, 50}}, {}, {}, QVector<Proc*> {spells->get_primal_fury()});
+
+    add_talent_to_tier(talent_tier, talent);
+}
+
+void FeralCombat::add_ferocity(QMap<QString, Talent*>& talent_tier) {
+    Talent* talent
+        = get_new_talent(druid, "Ferocity", "1ML", "Assets/ability/Ability_hunter_pet_hyena.png", 5,
+                        "Reduces the cost of your Maul, Swipe, Claw, and Rake abilities by %1 Rage or Energy.",
+                         QVector<QPair<unsigned, unsigned>> {{1, 1}},
+                         QVector<SpellRankGroup*> {spells->get_spell_rank_group_by_name("Maul"), spells->get_spell_rank_group_by_name("Swipe")});
+
+    add_talent_to_tier(talent_tier, talent);
+}
+
 void FeralCombat::add_feral_aggression(QMap<QString, Talent*>& talent_tier) {
     Talent* talent
         = get_new_talent(druid, "Feral Aggression", "1MR", "Assets/ability/Ability_druid_demoralizingroar2.png", 5,
@@ -95,7 +121,7 @@ void FeralCombat::add_feral_aggression(QMap<QString, Talent*>& talent_tier) {
 void FeralCombat::add_sharpened_claws(QMap<QString, Talent*>& talent_tier) {
     Talent* talent = get_new_talent(druid, "Sharpened Claws", "3MR", "Assets/items/Inv_misc_monsterclaw_04.png", 3,
                                     "Increases your critical strike chance while in Bear, Dire Bear or Cat Form by %1%.",
-                                    QVector<QPair<unsigned, unsigned>> {{2, 2}}, {}, QVector<Buff*> {spells->get_cat_form_buff()});
+                                    QVector<QPair<unsigned, unsigned>> {{2, 2}}, {}, QVector<Buff*> {spells->get_cat_form_buff(), spells->get_bear_form_buff()});
 
     add_talent_to_tier(talent_tier, talent);
 }
@@ -111,7 +137,7 @@ void FeralCombat::add_improved_shred(QMap<QString, Talent*>& talent_tier) {
 void FeralCombat::add_predatory_strikes(QMap<QString, Talent*>& talent_tier) {
     Talent* talent = get_new_talent(druid, "Predatory Strikes", "4ML", "Assets/ability/Ability_hunter_pet_cat.png", 3,
                                     "Increases your melee attack power in Cat, Bear and Dire Bear Forms by %1% of your level.",
-                                    QVector<QPair<unsigned, unsigned>> {{50, 50}}, {}, QVector<Buff*> {spells->get_cat_form_buff()});
+                                    QVector<QPair<unsigned, unsigned>> {{50, 50}}, {}, QVector<Buff*> {spells->get_cat_form_buff(), spells->get_bear_form_buff()});
 
     add_talent_to_tier(talent_tier, talent);
 }
@@ -129,7 +155,7 @@ void FeralCombat::add_heart_of_the_wild(QMap<QString, Talent*>& talent_tier) {
     Talent* talent = get_new_talent(druid, "Heart of the Wild", "6ML", "Assets/spell/Spell_holy_blessingofagility.png", 5,
                                     "Increases your Intellect by %1%. In addition, while in Bear or Dire Bear Form your Stamina is increased by %2% "
                                     "and while in Cat Form your Strength is increased by %3%.",
-                                    QVector<QPair<unsigned, unsigned>> {{4, 4}, {4, 4}, {4, 4}}, {}, QVector<Buff*> {spells->get_cat_form_buff()});
+                                    QVector<QPair<unsigned, unsigned>> {{4, 4}, {4, 4}, {4, 4}}, {}, QVector<Buff*> {spells->get_cat_form_buff(), spells->get_bear_form_buff()});
 
     add_talent_to_tier(talent_tier, talent);
 }
@@ -138,7 +164,7 @@ void FeralCombat::add_leader_of_the_pack(QMap<QString, Talent*>& talent_tier) {
     Talent* talent = get_new_talent(druid, "Leader of the Pack", "7ML", "Assets/spell/Spell_nature_unyeildingstamina.png", 1,
                                     "While in Cat, Bear or Dire Bear Form, the Leader of the Pack increases ranged and melee critical chance of all "
                                     "party members within 45 yards by 3%.",
-                                    QVector<QPair<unsigned, unsigned>>(), {}, QVector<Buff*> {spells->get_cat_form_buff()});
+                                    QVector<QPair<unsigned, unsigned>>(), {}, QVector<Buff*> {spells->get_cat_form_buff(), spells->get_bear_form_buff()});
 
     add_talent_to_tier(talent_tier, talent);
 }

--- a/Class/Druid/TalentTrees/FeralCombat.h
+++ b/Class/Druid/TalentTrees/FeralCombat.h
@@ -13,6 +13,10 @@ private:
     Druid* druid;
     DruidSpells* spells;
 
+    void add_feral_instinct(QMap<QString, Talent*>& talent_tier);
+    void add_savage_fury(QMap<QString, Talent*>& talent_tier);
+    void add_primal_fury(QMap<QString, Talent*>& talent_tier);
+    void add_ferocity(QMap<QString, Talent*>& talent_tier);
     void add_feral_aggression(QMap<QString, Talent*>& talent_tier);
     void add_sharpened_claws(QMap<QString, Talent*>& talent_tier);
     void add_improved_shred(QMap<QString, Talent*>& talent_tier);

--- a/ClassicSim.pro
+++ b/ClassicSim.pro
@@ -23,6 +23,7 @@ SOURCES += main.cpp \
     Class/Common/Spells/EssenceOfTheRed.cpp \
     Class/Common/Spells/PeriodicDamageSpell.cpp \
     Class/Common/Spells/UseItem.cpp \
+    Class/Druid/Buffs/BearFormBuff.cpp \
     Class/Druid/Buffs/CatFormBuff.cpp \
     Class/Druid/Buffs/LeaderOfThePack.cpp \
     Class/Druid/Buffs/MoonkinFormBuff.cpp \
@@ -32,15 +33,19 @@ SOURCES += main.cpp \
     Class/Druid/Procs/BloodFrenzy.cpp \
     Class/Druid/Procs/ClearcastingDruid.cpp \
     Class/Druid/Procs/Furor.cpp \
+    Class/Druid/Procs/PrimalFury.cpp \
     Class/Druid/Spells/BearForm.cpp \
     Class/Druid/Spells/CasterForm.cpp \
     Class/Druid/Spells/CatForm.cpp \
+    Class/Druid/Spells/Enrage.cpp \
     Class/Druid/Spells/FerociousBite.cpp \
     Class/Druid/Spells/MainhandAttackDruid.cpp \
+    Class/Druid/Spells/Maul.cpp \
     Class/Druid/Spells/Moonfire.cpp \
     Class/Druid/Spells/MoonkinForm.cpp \
     Class/Druid/Spells/Shred.cpp \
     Class/Druid/Spells/Starfire.cpp \
+    Class/Druid/Spells/Swipe.cpp \
     Class/Druid/Spells/TigersFury.cpp \
     Class/Druid/Spells/Wrath.cpp \
     Class/Druid/TalentTrees/Balance.cpp \
@@ -152,12 +157,16 @@ SOURCES += main.cpp \
     Spells/SpellRankGroup.cpp \
     Spells/UniqueDebuff.cpp \
     Talent/CharacterTalents.cpp \
+    Test/Druid/Spells/TestBearForm.cpp \
     Test/Druid/Spells/TestCatForm.cpp \
+    Test/Druid/Spells/TestEnrage.cpp \
     Test/Druid/Spells/TestFerociousBite.cpp \
+    Test/Druid/Spells/TestMaul.cpp \
     Test/Druid/Spells/TestMoonfire.cpp \
     Test/Druid/Spells/TestMoonkinForm.cpp \
     Test/Druid/Spells/TestShred.cpp \
     Test/Druid/Spells/TestStarfire.cpp \
+    Test/Druid/Spells/TestSwipe.cpp \
     Test/Druid/Spells/TestWrath.cpp \
     Test/Druid/Talents/TestBalance.cpp \
     Test/Druid/Talents/TestFeralCombat.cpp \
@@ -526,6 +535,7 @@ HEADERS += \
     Class/Common/Spells/EssenceOfTheRed.h \
     Class/Common/Spells/PeriodicDamageSpell.h \
     Class/Common/Spells/UseItem.h \
+    Class/Druid/Buffs/BearFormBuff.h \
     Class/Druid/Buffs/CatFormBuff.h \
     Class/Druid/Buffs/LeaderOfThePack.h \
     Class/Druid/Buffs/MoonkinFormBuff.h \
@@ -535,15 +545,19 @@ HEADERS += \
     Class/Druid/Procs/BloodFrenzy.h \
     Class/Druid/Procs/ClearcastingDruid.h \
     Class/Druid/Procs/Furor.h \
+    Class/Druid/Procs/PrimalFury.h \
     Class/Druid/Spells/BearForm.h \
     Class/Druid/Spells/CasterForm.h \
     Class/Druid/Spells/CatForm.h \
+    Class/Druid/Spells/Enrage.h \
     Class/Druid/Spells/FerociousBite.h \
     Class/Druid/Spells/MainhandAttackDruid.h \
+    Class/Druid/Spells/Maul.h \
     Class/Druid/Spells/Moonfire.h \
     Class/Druid/Spells/MoonkinForm.h \
     Class/Druid/Spells/Shred.h \
     Class/Druid/Spells/Starfire.h \
+    Class/Druid/Spells/Swipe.h \
     Class/Druid/Spells/TigersFury.h \
     Class/Druid/Spells/Wrath.h \
     Class/Druid/TalentTrees/Balance.h \
@@ -656,12 +670,16 @@ HEADERS += \
     Spells/UniqueDebuff.h \
     Statistics/RaidMemberResult.h \
     Talent/CharacterTalents.h \
+    Test/Druid/Spells/TestBearForm.h \
     Test/Druid/Spells/TestCatForm.h \
+    Test/Druid/Spells/TestEnrage.h \
     Test/Druid/Spells/TestFerociousBite.h \
+    Test/Druid/Spells/TestMaul.h \
     Test/Druid/Spells/TestMoonfire.h \
     Test/Druid/Spells/TestMoonkinForm.h \
     Test/Druid/Spells/TestShred.h \
     Test/Druid/Spells/TestStarfire.h \
+    Test/Druid/Spells/TestSwipe.h \
     Test/Druid/Spells/TestWrath.h \
     Test/Druid/Talents/TestBalance.h \
     Test/Druid/Talents/TestFeralCombat.h \

--- a/Equipment/Equipment.cpp
+++ b/Equipment/Equipment.cpp
@@ -1022,6 +1022,25 @@ void Equipment::unequip(Quiver*& current, const int eq_slot) {
     current = nullptr;
 }
 
+void Equipment::druid_bear_form_switch_to_paws() {
+    mh_enchant = get_current_enchant_enum_value(mainhand);
+    mh_temp_enchant = get_current_temp_enchant_enum_value(mainhand);
+
+    if (mainhand) {
+        mainhand->disable_proc_effects();
+        mainhand->disable_druid_form_enchants();
+    }
+
+    druid_form_mh_storage = mainhand;
+    druid_form_oh_storage = offhand;
+
+    mainhand = nullptr;
+    offhand = nullptr;
+
+    // Druid paws are created as hidden items with an item id of 11223400 + clvl
+    set_mainhand(11223400 + static_cast<int>(pchar->get_clvl()));
+}
+
 void Equipment::druid_cat_form_switch_to_claws() {
     mh_enchant = get_current_enchant_enum_value(mainhand);
     mh_temp_enchant = get_current_temp_enchant_enum_value(mainhand);

--- a/Equipment/Equipment.h
+++ b/Equipment/Equipment.h
@@ -110,6 +110,7 @@ public:
     void equip(Quiver*& current, Quiver* next, const int eq_slot);
     void unequip(Quiver*& current, const int eq_slot);
 
+    void druid_bear_form_switch_to_paws();
     void druid_cat_form_switch_to_claws();
     void druid_switch_to_normal_weapon();
 

--- a/Equipment/EquipmentDb/Belts/leather.xml
+++ b/Equipment/EquipmentDb/Belts/leather.xml
@@ -167,4 +167,61 @@
 		Quest reward. Requires boss drops from Naxxramas.
 		</source>
 	</item>
+	
+	<item id="19163" phase="3">
+		<info name="Molten Belt" type="LEATHER" slot="BELT" unique="no" req_lvl="60" item_lvl="70" quality="EPIC" boe="no" icon="Inv_belt_13.png"/>
+		<stats>
+			<stat type="ARMOR" value="118"/>
+			<stat type="AGILITY" value="28"/>
+			<stat type="STAMINA" value="16"/>
+			<stat type="FIRE_RESISTANCE" value="12"/>
+		</stats>
+		<source>
+		Crafted by Leatherworkers with Thorium Brotherhood reputation. Requires Molten Core materials.
+		</source>
+	</item>
+	
+	<item id="21675" phase="5">
+		<info name="Thick Qirajihide Belt" type="LEATHER" slot="BELT" unique="no" req_lvl="60" item_lvl="76" quality="EPIC" boe="no" icon="Inv_belt_15.png"/>
+		<stats>
+			<stat type="ARMOR" value="186"/>
+			<stat type="STRENGTH" value="10"/>
+			<stat type="STAMINA" value="20"/>
+			<stat type="AGILITY" value="17"/>
+			<stat type="PARRY_CHANCE" value="0.01"/>
+		</stats>
+		<source>
+		Drops from Battleguard Sartura (AQ40).
+		</source>
+	</item>
+	
+	<item id="20190" phase="4">
+		<info name="Defiler's Leather Girdle" type="LEATHER" slot="BELT" unique="no" req_lvl="60" item_lvl="63" quality="EPIC" boe="no" icon="Inv_belt_17.png"/>
+		<class_restriction class="DRUID"/>
+		<class_restriction class="ROGUE"/>
+		<stats>
+			<stat type="ARMOR" value="159"/>
+			<stat type="STAMINA" value="7"/>
+			<stat type="CRIT_CHANCE" value="0.01"/>
+			<stat type="ATTACK_POWER" value="34"/>
+		</stats>
+		<source>
+		Sold by Arathi Basin vendors (Rutherford Twing for Horde).
+		</source>
+	</item>
+	
+	<item id="20045" phase="4">
+		<info name="Highlander's Leather Girdle" type="LEATHER" slot="BELT" unique="no" req_lvl="60" item_lvl="63" quality="EPIC" boe="no" icon="Inv_belt_17.png"/>
+		<class_restriction class="DRUID"/>
+		<class_restriction class="ROGUE"/>
+		<stats>
+			<stat type="ARMOR" value="159"/>
+			<stat type="STAMINA" value="7"/>
+			<stat type="CRIT_CHANCE" value="0.01"/>
+			<stat type="ATTACK_POWER" value="34"/>
+		</stats>
+		<source>
+		Sold by Arathi Basin vendors (for Alliance).
+		</source>
+	</item>
 </items>

--- a/Equipment/EquipmentDb/Boots/leather.xml
+++ b/Equipment/EquipmentDb/Boots/leather.xml
@@ -229,4 +229,34 @@
 		Quest reward. Requires boss drops from Naxxramas.
 		</source>
 	</item>
+	
+	<item id="20186" phase="4">
+		<info name="Defiler's Leather Boots" type="LEATHER" slot="BOOTS" unique="no" req_lvl="58" item_lvl="63" quality="RARE" boe="no" icon="Inv_boots_cloth_05.png"/>
+		<class_restriction class="ROGUE"/>
+		<class_restriction class="DRUID"/>
+		<stats>
+			<stat type="ARMOR" value="181"/>
+			<stat type="AGILITY" value="12"/>
+			<stat type="STAMINA" value="16"/>
+			<stat type="ATTACK_POWER" value="16"/>
+		</stats>
+		<source>
+		Sold by Arathi Basin vendors (Rutherford Twing for Horde).
+		</source>
+	</item>
+	
+	<item id="20052" phase="4">
+		<info name="Highlander's Leather Boots" type="LEATHER" slot="BOOTS" unique="no" req_lvl="58" item_lvl="63" quality="RARE" boe="no" icon="Inv_boots_cloth_05.png"/>
+		<class_restriction class="ROGUE"/>
+		<class_restriction class="DRUID"/>
+		<stats>
+			<stat type="ARMOR" value="181"/>
+			<stat type="AGILITY" value="12"/>
+			<stat type="STAMINA" value="16"/>
+			<stat type="ATTACK_POWER" value="16"/>
+		</stats>
+		<source>
+		Sold by Arathi Basin vendors (for Alliance).
+		</source>
+	</item>
 </items>

--- a/Equipment/EquipmentDb/EquipmentDb.cpp
+++ b/Equipment/EquipmentDb/EquipmentDb.cpp
@@ -15,6 +15,7 @@
 EquipmentDb::EquipmentDb(QObject* parent) : QObject(parent) {
     read_equipment_files();
     add_druid_cat_form_claws();
+    add_druid_bear_form_paws();
     set_content_phase(Content::Phase::Naxxramas);
 
     all_slots_items = {&mh_slot_items, &oh_slot_items, &ranged_items, &helms, &amulets,  &shoulders,   &backs,  &chests,  &wrists, &gloves,
@@ -54,6 +55,17 @@ void EquipmentDb::add_druid_cat_form_claws() {
         Weapon* claw = new Weapon(QString("Claw level %1").arg(i), item_id, Content::Phase::MoltenCore, WeaponTypes::FIST, WeaponSlots::MAINHAND,
                                   min_dmg, max_dmg, 1.0);
         add_melee_weapon(claw);
+    }
+}
+
+void EquipmentDb::add_druid_bear_form_paws() {
+    for (int i = 1; i <= 60; ++i) {
+        const unsigned min_dmg = static_cast<unsigned>(std::max(1, static_cast<int>(std::round(2.5 * i * 0.85))));
+        const unsigned max_dmg = static_cast<unsigned>(std::max(1, static_cast<int>(std::round(2.5 * i * 1.25))));
+        const int item_id = 11223400 + i;
+        Weapon* paws = new Weapon(QString("Paws level %1").arg(i), item_id, Content::Phase::MoltenCore, WeaponTypes::FIST, WeaponSlots::MAINHAND,
+                                  min_dmg, max_dmg, 2.5);
+        add_melee_weapon(paws);
     }
 }
 

--- a/Equipment/EquipmentDb/EquipmentDb.h
+++ b/Equipment/EquipmentDb/EquipmentDb.h
@@ -63,6 +63,7 @@ private:
     void delete_items(QVector<Item*>*);
     void add_item_id(Item* item);
     void add_druid_cat_form_claws();
+    void add_druid_bear_form_paws();
 
     QVector<Item*> mh_slot_items;
     QVector<Item*> current_phase_mh_slot_items;

--- a/Equipment/EquipmentDb/Legs/leather.xml
+++ b/Equipment/EquipmentDb/Legs/leather.xml
@@ -167,4 +167,16 @@
 		Crafted by Leatherworkers.
 		</source>
 	</item>
+	
+	<item id="19889" phase="4">
+		<info name="Blooddrenched Leggings" type="LEATHER" slot="LEGS" unique="no" req_lvl="60" item_lvl="71" quality="RARE" boe="no" icon="Inv_pants_leather_09.png"/>
+		<stats>
+			<stat type="ARMOR" value="170"/>
+			<stat type="AGILITY" value="35"/>
+			<stat type="STAMINA" value="15"/>
+		</stats>
+		<source>
+		Drops from Jin'do the Hexxer in Zul'Gurub.
+		</source>
+	</item>
 </items>

--- a/Equipment/EquipmentDb/Shoulders/leather.xml
+++ b/Equipment/EquipmentDb/Shoulders/leather.xml
@@ -206,4 +206,34 @@
 		Crafted by Leatherworkers.
 		</source>
 	</item>
+	
+	<item id="20194" phase="4">
+		<info name="Defiler's Leather Shoulders" type="LEATHER" slot="SHOULDERS" unique="yes" req_lvl="60" item_lvl="65" quality="EPIC" boe="no" icon="Inv_shoulder_24.png"/>
+		<class_restriction class="ROGUE"/>
+		<class_restriction class="DRUID"/>
+		<stats>
+			<stat type="ARMOR" value="258"/>
+			<stat type="AGILITY" value="18"/>
+			<stat type="STAMINA" value="17"/>
+			<stat type="ATTACK_POWER" value="30"/>
+		</stats>
+		<source>
+		Sold by Arathi Basin vendors (Rutherford Twing for Horde).
+		</source>
+	</item>
+	
+	<item id="20059" phase="4">
+		<info name="Highlander's Leather Shoulders" type="LEATHER" slot="SHOULDERS" unique="yes" req_lvl="60" item_lvl="65" quality="EPIC" boe="no" icon="Inv_shoulder_24.png"/>
+		<class_restriction class="ROGUE"/>
+		<class_restriction class="DRUID"/>
+		<stats>
+			<stat type="ARMOR" value="258"/>
+			<stat type="AGILITY" value="18"/>
+			<stat type="STAMINA" value="17"/>
+			<stat type="ATTACK_POWER" value="30"/>
+		</stats>
+		<source>
+		Sold by Arathi Basin vendors (for Alliance).
+		</source>
+	</item>
 </items>

--- a/Equipment/EquipmentDb/set_bonuses.xml
+++ b/Equipment/EquipmentDb/set_bonuses.xml
@@ -1011,4 +1011,29 @@
 		</bonus>
 	</set>
 	
+	<set name="The Defiler's Purpose">
+		<item_id value="20186"/>
+		<item_id value="20190"/>
+		<item_id value="20194"/>
+	
+		<bonus value="2" item_stat="STAMINA" stat_value="5">
+			(2) Set: 5 Stamina
+		</bonus>
+		<bonus value="3" item_stat="CRIT_CHANCE" stat_value="100">
+			(3) Set: Improves your chance to get a critical strike by 1%.
+		</bonus>
+	</set>
+
+	<set name="The Highlander's Purpose">
+		<item_id value="20052"/>
+		<item_id value="20045"/>
+		<item_id value="20059"/>
+	
+		<bonus value="2" item_stat="STAMINA" stat_value="5">
+			(2) Set: 5 Stamina
+		</bonus>
+		<bonus value="3" item_stat="CRIT_CHANCE" stat_value="100">
+			(3) Set: Improves your chance to get a critical strike by 1%.
+		</bonus>
+	</set>
 </sets>

--- a/QML/Assets/ability/Ability_druid_maul.png
+++ b/QML/Assets/ability/Ability_druid_maul.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02882888298978512947fc7ffd5ea26498bc1167b6e6b02a547d79a4a9baeab5
+size 10102

--- a/QML/Assets/ability/Ability_druid_swipe.png
+++ b/QML/Assets/ability/Ability_druid_swipe.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:759e7db355d0191db90dc4278165d3cc70e9aca3da314c404a5d9833e6d1d3df
+size 9400

--- a/Rotation/Rotations/Druid/FeralTank.xml
+++ b/Rotation/Rotations/Druid/FeralTank.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<rotation class="Druid" name="Feral Tank Maul" attack_mode="melee">
+    <description>
+    A rotation using Maul only.
+    </description>
+
+    <precombat_actions>
+        <spell name="Bear Form"/>
+    </precombat_actions>
+
+    <cast_if name="Manual Crowd Pummeler"/>
+    <cast_if name="Kiss of the Spider"/>
+    <cast_if name="Jom Gabbar"/>
+    <cast_if name="Badge of the Swarmguard"/>
+    <cast_if name="Slayer's Crest"/>
+    <cast_if name="Earthstrike"/>
+    <cast_if name="Zandalarian Hero Medallion"/>
+	
+	<cast_if name="Bear Form"/>
+	
+	<cast_if name="Enrage"/>
+	
+    <cast_if name="Maul"/>
+	
+	<cast_if name="Swipe">
+		resource "Rage" greater 40
+    </cast_if>
+</rotation>

--- a/Rotation/Rotations/rotation_paths.xml
+++ b/Rotation/Rotations/rotation_paths.xml
@@ -27,5 +27,6 @@
     <file path="Rotations/Warlock/ShadowBolt.xml"/>
 
     <file path="Rotations/Druid/FeralPowershifting.xml"/>
+	<file path="Rotations/Druid/FeralTank.xml"/>
     <file path="Rotations/Druid/Starfire.xml"/>
 </paths>

--- a/Test/Druid/Spells/TestBearForm.cpp
+++ b/Test/Druid/Spells/TestBearForm.cpp
@@ -1,0 +1,363 @@
+#include "TestBearForm.h"
+
+#include <cassert>
+
+#include "BearForm.h"
+#include "Buff.h"
+#include "CharacterStats.h"
+#include "Druid.h"
+#include "DruidSpells.h"
+#include "EnchantProc.h"
+#include "Equipment.h"
+#include "Event.h"
+#include "RaidControl.h"
+#include "Weapon.h"
+
+TestBearForm::TestBearForm(EquipmentDb* equipment_db) : TestSpellDruid(equipment_db, "Bear Form") {}
+
+void TestBearForm::test_all() {
+    run_mandatory_tests();
+
+    set_up();
+    test_resource_cost_with_3_of_3_natural_shapeshifter();
+    tear_down();
+
+    set_up();
+    test_paws_equipped_upon_entering_bear_form();
+    tear_down();
+
+    set_up();
+    test_proc_enchants_on_weapon_disabled_in_bear_form();
+    tear_down();
+
+    set_up();
+    test_attack_speed_in_and_out_of_bear_form();
+    tear_down();
+
+    set_up();
+    test_hit_dmg();
+    tear_down();
+
+    set_up();
+    test_hit_dmg_0_of_5_feral_instinct();
+    tear_down();
+
+    set_up();
+    test_hit_dmg_1_of_5_feral_instinct();
+    tear_down();
+
+    set_up();
+    test_hit_dmg_2_of_5_feral_instinct();
+    tear_down();
+
+    set_up();
+    test_hit_dmg_3_of_5_feral_instinct();
+    tear_down();
+
+    set_up();
+    test_hit_dmg_4_of_5_feral_instinct();
+    tear_down();
+
+    set_up();
+    test_hit_dmg_5_of_5_feral_instinct();
+    tear_down();
+
+    set_up();
+    test_crit_dmg();
+    tear_down();
+
+    set_up();
+    test_glancing_dmg();
+    tear_down();
+
+    set_up();
+    test_leader_of_the_pack_gives_crit_to_party_members();
+    tear_down();
+
+    set_up();
+    test_0_of_5_furor_gives_0_rage_on_entering_bear_form();
+    tear_down();
+
+    set_up(false);
+    test_5_of_5_furor_gives_10_rage_on_entering_bear_form();
+    tear_down();
+}
+
+void TestBearForm::test_name_correct() {
+    assert(bear_form()->get_name() == "Bear Form");
+}
+
+void TestBearForm::test_spell_cooldown() {
+    assert(almost_equal(0.0, bear_form()->get_base_cooldown()));
+}
+
+void TestBearForm::test_whether_spell_causes_global_cooldown() {
+    assert(druid->action_ready());
+
+    when_bear_form_is_performed();
+
+    assert(!druid->action_ready());
+}
+
+void TestBearForm::test_how_spell_observes_global_cooldown() {}
+
+void TestBearForm::test_is_ready_conditions() {
+    assert(bear_form()->get_spell_status() == SpellStatus::Available);
+}
+
+void TestBearForm::test_resource_cost() {
+    given_druid_has_mana(101);
+
+    when_bear_form_is_performed();
+
+    then_druid_has_mana(1);
+}
+
+void TestBearForm::test_resource_cost_with_3_of_3_natural_shapeshifter() {
+    given_balance_talent_rank("Natural Shapeshifter", 3);
+    given_druid_has_mana(71);
+
+    when_bear_form_is_performed();
+
+    then_druid_has_mana(1);
+}
+
+void TestBearForm::test_paws_equipped_upon_entering_bear_form() {
+    given_staff_equipped(druid);
+
+    when_bear_form_is_performed();
+
+    assert(pchar->get_equipment()->get_mainhand() != nullptr);
+    assert(pchar->get_equipment()->get_mainhand()->name == "Paws level 60");
+}
+
+void TestBearForm::test_proc_enchants_on_weapon_disabled_in_bear_form() {
+    given_staff_equipped(druid);
+    Weapon* mh = pchar->get_equipment()->get_mainhand();
+    mh->apply_enchant(EnchantName::Crusader, druid, WeaponSlots::MAINHAND);
+    mh->apply_temporary_enchant(EnchantName::ShadowOil, druid, WeaponSlots::MAINHAND);
+    assert(true == static_cast<EnchantProc*>(mh->get_enchant())->proc_enabled());
+    assert(true == static_cast<EnchantProc*>(mh->get_enchant())->proc_enabled());
+
+    when_bear_form_is_performed();
+    assert(false == static_cast<EnchantProc*>(mh->get_enchant())->proc_enabled());
+    assert(false == static_cast<EnchantProc*>(mh->get_enchant())->proc_enabled());
+
+    druid->cancel_form();
+    assert(true == static_cast<EnchantProc*>(mh->get_enchant())->proc_enabled());
+    assert(true == static_cast<EnchantProc*>(mh->get_enchant())->proc_enabled());
+}
+
+void TestBearForm::test_attack_speed_in_and_out_of_bear_form() {
+    given_event_is_ignored(EventType::PlayerAction);
+    given_event_is_ignored(EventType::DotTick);
+    given_in_melee_attack_mode();
+    given_staff_equipped(druid);
+    pchar->get_spells()->start_attack();
+
+    then_next_event_is(EventType::MainhandMeleeHit, "0.000", RUN_EVENT);
+    when_bear_form_is_performed();
+    then_next_event_is(EventType::MainhandMeleeHit, "3.800", RUN_EVENT);
+    then_next_event_is(EventType::MainhandMeleeHit, "6.300", RUN_EVENT);
+    then_next_event_is(EventType::MainhandMeleeHit, "8.800", RUN_EVENT);
+    druid->cancel_form();
+    then_next_event_is(EventType::MainhandMeleeHit, "11.300", RUN_EVENT);
+    then_next_event_is(EventType::MainhandMeleeHit, "15.100", RUN_EVENT);
+}
+
+void TestBearForm::test_hit_dmg() {
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    when_bear_form_is_performed();
+    given_1000_melee_ap();
+    given_a_guaranteed_white_hit();
+    pchar->get_spells()->start_attack();
+
+    then_next_event_is(EventType::MainhandMeleeHit, "0.000", RUN_EVENT);
+
+    // [Damage] = [min - max] + AP / 14
+    // [306 - 367] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14)
+    then_damage_dealt_is_in_range(306, 367);
+}
+
+void TestBearForm::test_hit_dmg_0_of_5_feral_instinct() {
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    when_bear_form_is_performed();
+    given_1000_melee_ap();
+    given_a_guaranteed_white_hit();
+    pchar->get_spells()->start_attack();
+
+    then_next_event_is(EventType::MainhandMeleeHit, "0.000", RUN_EVENT);
+
+    // [Damage] = [min - max] + AP / 14
+    // [306 - 367] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14)
+    then_damage_dealt_is_in_range(306, 367);
+
+    then_threat_dealt_is_in_range(306 * 1.3, 367 * 1.3 + 1);
+}
+
+void TestBearForm::test_hit_dmg_1_of_5_feral_instinct() {
+    given_feral_talent_rank("Feral Instinct", 1);
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    when_bear_form_is_performed();
+    given_1000_melee_ap();
+    given_a_guaranteed_white_hit();
+    pchar->get_spells()->start_attack();
+
+    then_next_event_is(EventType::MainhandMeleeHit, "0.000", RUN_EVENT);
+
+    // [Damage] = [min - max] + AP / 14
+    // [306 - 367] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14)
+    then_damage_dealt_is_in_range(306, 367);
+
+    then_threat_dealt_is_in_range(306 * (1.3 + 0.03), 367 * (1.3 + 0.03) + 1);
+}
+
+void TestBearForm::test_hit_dmg_2_of_5_feral_instinct() {
+    given_feral_talent_rank("Feral Instinct", 2);
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    when_bear_form_is_performed();
+    given_1000_melee_ap();
+    given_a_guaranteed_white_hit();
+    pchar->get_spells()->start_attack();
+
+    then_next_event_is(EventType::MainhandMeleeHit, "0.000", RUN_EVENT);
+
+    // [Damage] = [min - max] + AP / 14
+    // [306 - 367] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14)
+    then_damage_dealt_is_in_range(306, 367);
+
+    then_threat_dealt_is_in_range(306 * (1.3 + 0.06), 367 * (1.3 + 0.06) + 1);
+}
+
+void TestBearForm::test_hit_dmg_3_of_5_feral_instinct() {
+    given_feral_talent_rank("Feral Instinct", 3);
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    when_bear_form_is_performed();
+    given_1000_melee_ap();
+    given_a_guaranteed_white_hit();
+    pchar->get_spells()->start_attack();
+
+    then_next_event_is(EventType::MainhandMeleeHit, "0.000", RUN_EVENT);
+
+    // [Damage] = [min - max] + AP / 14
+    // [306 - 367] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14)
+    then_damage_dealt_is_in_range(306, 367);
+
+    then_threat_dealt_is_in_range(306 * (1.3 + 0.09), 367 * (1.3 + 0.09) + 1);
+}
+
+void TestBearForm::test_hit_dmg_4_of_5_feral_instinct() {
+    given_feral_talent_rank("Feral Instinct", 4);
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    when_bear_form_is_performed();
+    given_1000_melee_ap();
+    given_a_guaranteed_white_hit();
+    pchar->get_spells()->start_attack();
+
+    then_next_event_is(EventType::MainhandMeleeHit, "0.000", RUN_EVENT);
+
+    // [Damage] = [min - max] + AP / 14
+    // [306 - 367] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14)
+    then_damage_dealt_is_in_range(306, 367);
+
+    then_threat_dealt_is_in_range(306 * (1.3 + 0.12), 367 * (1.3 + 0.12) + 1);
+}
+
+void TestBearForm::test_hit_dmg_5_of_5_feral_instinct() {
+    given_feral_talent_rank("Feral Instinct", 5);
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    when_bear_form_is_performed();
+    given_1000_melee_ap();
+    given_a_guaranteed_white_hit();
+    pchar->get_spells()->start_attack();
+
+    then_next_event_is(EventType::MainhandMeleeHit, "0.000", RUN_EVENT);
+
+    // [Damage] = [min - max] + AP / 14
+    // [306 - 367] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14)
+    then_damage_dealt_is_in_range(306, 367);
+
+    then_threat_dealt_is_in_range(306 * (1.3 + 0.15), 367 * (1.3 + 0.15) + 1);
+}
+
+void TestBearForm::test_crit_dmg() {
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    when_bear_form_is_performed();
+    given_1000_melee_ap();
+    given_a_guaranteed_white_crit();
+    pchar->get_spells()->start_attack();
+
+    then_next_event_is(EventType::MainhandMeleeHit, "0.000", RUN_EVENT);
+
+    // [Damage] = ([min - max] + AP / 14) * crit_dmg_modifier
+    // [613 - 733] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14) * 2.0
+    then_damage_dealt_is_in_range(613, 733);
+}
+
+void TestBearForm::test_glancing_dmg() {
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    when_bear_form_is_performed();
+    given_1000_melee_ap();
+    given_a_guaranteed_white_glancing_blow();
+    pchar->get_spells()->start_attack();
+
+    then_next_event_is(EventType::MainhandMeleeHit, "0.000", RUN_EVENT);
+
+    // [Damage] = ([min - max] + AP / 14) * glancing_dmg_modifier
+    // [168 - 275] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14) * [0.55 - 0.75]
+    then_damage_dealt_is_in_range(168, 275);
+}
+
+void TestBearForm::test_leader_of_the_pack_gives_crit_to_party_members() {
+    Druid* druid_2 = new Druid(race, equipment_db, sim_settings, raid_control, 0, 1);
+    given_feral_talent_rank("Leader of the Pack", 1);
+
+    const unsigned self_melee_crit_before = pchar->get_stats()->get_mh_crit_chance();
+    const unsigned druid_2_melee_crit_before = druid_2->get_stats()->get_mh_crit_chance();
+
+    when_bear_form_is_performed();
+
+    const unsigned aura_suppression = 180;
+    assert(self_melee_crit_before + 300 - aura_suppression == pchar->get_stats()->get_mh_crit_chance());
+    assert(druid_2_melee_crit_before + 300 - aura_suppression == druid_2->get_stats()->get_mh_crit_chance());
+
+    given_engine_priority_pushed_forward(1.01);
+    druid->cancel_form();
+    assert(druid->get_current_form() == DruidForm::Caster);
+
+    assert(self_melee_crit_before == pchar->get_stats()->get_mh_crit_chance());
+    assert(druid_2_melee_crit_before == druid_2->get_stats()->get_mh_crit_chance());
+
+    delete druid_2;
+}
+
+void TestBearForm::test_0_of_5_furor_gives_0_rage_on_entering_bear_form() {
+    given_druid_has_energy(0);
+
+    when_bear_form_is_performed();
+
+    then_druid_has_energy(0);
+}
+
+void TestBearForm::test_5_of_5_furor_gives_10_rage_on_entering_bear_form() {
+    given_restoration_talent_rank("Furor", 5);
+    given_druid_has_energy(0);
+    pchar->prepare_set_of_combat_iterations();
+
+    when_bear_form_is_performed();
+
+    then_druid_has_rage(10);
+}
+
+void TestBearForm::when_bear_form_is_performed() {
+    bear_form()->perform();
+}

--- a/Test/Druid/Spells/TestBearForm.h
+++ b/Test/Druid/Spells/TestBearForm.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "TestSpellDruid.h"
+
+class TestBearForm : public TestSpellDruid {
+public:
+    TestBearForm(EquipmentDb* equipment_db);
+
+    void test_all();
+
+private:
+    void test_name_correct() override;
+    void test_spell_cooldown() override;
+    void test_whether_spell_causes_global_cooldown() override;
+    void test_how_spell_observes_global_cooldown() override;
+    void test_resource_cost() override;
+    void test_is_ready_conditions() override;
+    void test_resource_cost_with_3_of_3_natural_shapeshifter();
+    void test_paws_equipped_upon_entering_bear_form();
+    void test_proc_enchants_on_weapon_disabled_in_bear_form();
+    void test_attack_speed_in_and_out_of_bear_form();
+    void test_hit_dmg_0_of_5_feral_instinct();
+    void test_hit_dmg_1_of_5_feral_instinct();
+    void test_hit_dmg_2_of_5_feral_instinct();
+    void test_hit_dmg_3_of_5_feral_instinct();
+    void test_hit_dmg_4_of_5_feral_instinct();
+    void test_hit_dmg_5_of_5_feral_instinct();
+    void test_hit_dmg();
+    void test_crit_dmg();
+    void test_glancing_dmg();
+    void test_leader_of_the_pack_gives_crit_to_party_members();
+    void test_0_of_5_furor_gives_0_rage_on_entering_bear_form();
+    void test_5_of_5_furor_gives_10_rage_on_entering_bear_form();
+
+    void when_bear_form_is_performed();
+};

--- a/Test/Druid/Spells/TestEnrage.cpp
+++ b/Test/Druid/Spells/TestEnrage.cpp
@@ -1,0 +1,104 @@
+#include "TestEnrage.h"
+
+#include <cassert>
+
+#include "BearForm.h"
+#include "Druid.h"
+#include "DruidSpells.h"
+#include "Engine.h"
+#include "Enrage.h"
+#include "Event.h"
+#include "Queue.h"
+
+TestEnrage::TestEnrage(EquipmentDb* equipment_db) : TestSpellDruid(equipment_db, "Enrage") {}
+
+void TestEnrage::test_all() {
+    run_mandatory_tests();
+
+    set_up();
+    test_improved_enrage_1_of_2_gain_5_rage_immediately();
+    tear_down();
+
+    set_up();
+    test_improved_enrage_2_of_2_gain_10_rage_immediately();
+    tear_down();
+
+    set_up();
+    test_gain_20_rage_over_10_seconds();
+    tear_down();
+}
+
+Enrage* TestEnrage::enrage() const {
+    return static_cast<Enrage*>(get_max_rank_spell_by_name("Enrage"));
+}
+
+void TestEnrage::test_name_correct() {
+    assert(enrage()->get_name() == "Enrage");
+}
+
+void TestEnrage::test_spell_cooldown() {
+    assert(QString::number(enrage()->get_base_cooldown(), 'f', 3) == "60.000");
+}
+
+void TestEnrage::test_whether_spell_causes_global_cooldown() {
+    when_enrage_is_performed();
+
+    assert(druid->action_ready());
+}
+
+void TestEnrage::test_how_spell_observes_global_cooldown() {
+    assert(enrage()->get_spell_status() == SpellStatus::Available);
+
+    given_druid_is_on_gcd(enrage());
+
+    assert(enrage()->get_spell_status() == SpellStatus::Available);
+}
+
+void TestEnrage::test_is_ready_conditions() {
+    assert(enrage()->get_spell_status() == SpellStatus::InCasterForm);
+}
+
+void TestEnrage::test_resource_cost() {
+    druid->lose_rage(druid->get_resource_level(ResourceType::Rage));
+    assert(enrage()->get_spell_status() == SpellStatus::Available);
+}
+
+void TestEnrage::test_improved_enrage_1_of_2_gain_5_rage_immediately() {
+    given_druid_has_rage(0);
+
+    when_enrage_is_performed();
+
+    given_druid_has_rage(5);
+}
+
+void TestEnrage::test_improved_enrage_2_of_2_gain_10_rage_immediately() {
+    given_druid_has_rage(0);
+
+    when_enrage_is_performed();
+
+    given_druid_has_rage(10);
+}
+
+void TestEnrage::test_gain_20_rage_over_10_seconds() {
+    given_druid_has_rage(0);
+
+    when_enrage_is_performed();
+
+    then_periodic_enrage_rage_gain_is(20);
+}
+
+void TestEnrage::when_enrage_is_performed() {
+    enrage()->perform();
+}
+
+void TestEnrage::then_periodic_enrage_rage_gain_is(const unsigned expected_rage_gain) {
+    const unsigned prev = druid->get_resource_level(ResourceType::Rage);
+
+    when_running_queued_events_until(10.01);
+
+    assert(druid->get_resource_level(ResourceType::Rage) - prev == expected_rage_gain);
+}
+
+void TestEnrage::given_druid_in_bear_form() {
+    bear_form()->perform();
+}

--- a/Test/Druid/Spells/TestEnrage.h
+++ b/Test/Druid/Spells/TestEnrage.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "TestSpellDruid.h"
+
+class TestEnrage : public TestSpellDruid {
+public:
+    TestEnrage(EquipmentDb* equipment_db);
+
+    void test_all();
+
+private:
+    Enrage* enrage() const;
+
+    void test_name_correct() override;
+    void test_spell_cooldown() override;
+    void test_whether_spell_causes_global_cooldown() override;
+    void test_how_spell_observes_global_cooldown() override;
+    void test_resource_cost() override;
+    void test_is_ready_conditions() override;
+
+    void test_improved_enrage_1_of_2_gain_5_rage_immediately();
+    void test_improved_enrage_2_of_2_gain_10_rage_immediately();
+    void test_gain_20_rage_over_10_seconds();
+
+    void when_enrage_is_performed();
+
+    void then_periodic_enrage_rage_gain_is(const unsigned expected_rage_gain);
+
+    void given_druid_in_bear_form();
+};

--- a/Test/Druid/Spells/TestMaul.cpp
+++ b/Test/Druid/Spells/TestMaul.cpp
@@ -1,0 +1,246 @@
+#include "TestMaul.h"
+
+#include <cassert>
+
+#include "BearForm.h"
+#include "Buff.h"
+#include "ClassStatistics.h"
+#include "Druid.h"
+#include "DruidSpells.h"
+#include "Maul.h"
+
+TestMaul::TestMaul(EquipmentDb* equipment_db) : TestSpellDruid(equipment_db, "Maul") {}
+
+void TestMaul::test_all() {
+    run_mandatory_tests();
+
+    set_up();
+    test_resource_cost_1_of_5_ferocity();
+    tear_down();
+
+    set_up();
+    test_resource_cost_2_of_5_ferocity();
+    tear_down();
+
+    set_up();
+    test_resource_cost_3_of_5_ferocity();
+    tear_down();
+
+    set_up();
+    test_resource_cost_4_of_5_ferocity();
+    tear_down();
+
+    set_up();
+    test_resource_cost_5_of_5_ferocity();
+    tear_down();
+
+    set_up();
+    test_hit_dmg();
+    tear_down();
+
+    set_up();
+    test_hit_threat();
+    tear_down();
+
+    set_up();
+    test_crit_dmg();
+    tear_down();
+}
+
+void TestMaul::test_name_correct() {
+    assert(maul()->get_name() == "Maul");
+}
+
+void TestMaul::test_spell_cooldown() {
+    assert(almost_equal(0.0, maul()->get_base_cooldown()));
+}
+
+void TestMaul::test_whether_spell_causes_global_cooldown() {
+    given_druid_in_bear_form();
+    given_engine_priority_at(0.51);
+    given_druid_has_rage(100);
+    assert(druid->action_ready());
+
+    when_maul_is_performed();
+
+    assert(druid->action_ready());
+}
+
+void TestMaul::test_how_spell_observes_global_cooldown() {}
+
+void TestMaul::test_resource_cost() {
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_druid_has_rage(100);
+    given_engine_priority_at(0.51);
+
+    when_maul_is_performed();
+
+    then_druid_has_rage(85);
+}
+
+void TestMaul::test_is_ready_conditions() {
+    assert(maul()->get_spell_status() == SpellStatus::InsufficientResources);
+
+    given_druid_in_bear_form();
+    given_engine_priority_at(0.51);
+
+    assert(maul()->get_spell_status() == SpellStatus::InsufficientResources);
+
+    given_druid_has_rage(100);
+
+    assert(maul()->get_spell_status() == SpellStatus::Available);
+}
+
+void TestMaul::test_resource_cost_1_of_5_ferocity() {
+    given_feral_talent_rank("Ferocity", 1);
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_druid_has_rage(100);
+    given_engine_priority_at(0.51);
+
+    when_maul_is_performed();
+
+    then_druid_has_rage(86);
+}
+
+void TestMaul::test_resource_cost_2_of_5_ferocity() {
+    given_feral_talent_rank("Ferocity", 2);
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_druid_has_rage(100);
+    given_engine_priority_at(0.51);
+
+    when_maul_is_performed();
+
+    then_druid_has_rage(87);
+}
+
+void TestMaul::test_resource_cost_3_of_5_ferocity() {
+    given_feral_talent_rank("Ferocity", 3);
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_druid_has_rage(100);
+    given_engine_priority_at(0.51);
+
+    when_maul_is_performed();
+
+    then_druid_has_rage(88);
+}
+
+void TestMaul::test_resource_cost_4_of_5_ferocity() {
+    given_feral_talent_rank("Ferocity", 4);
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_druid_has_rage(100);
+    given_engine_priority_at(0.51);
+
+    when_maul_is_performed();
+
+    then_druid_has_rage(89);
+}
+
+void TestMaul::test_resource_cost_5_of_5_ferocity() {
+    given_feral_talent_rank("Ferocity", 5);
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_druid_has_rage(100);
+    given_engine_priority_at(0.51);
+
+    when_maul_is_performed();
+
+    then_druid_has_rage(90);
+}
+
+void TestMaul::test_hit_dmg_1_of_2_savage_fury() {
+    given_feral_talent_rank("Savage Fury", 1);
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    given_druid_in_bear_form();
+    given_1000_melee_ap();
+    given_druid_has_rage(100);
+    given_a_guaranteed_melee_ability_hit();
+    given_engine_priority_at(0.51);
+
+    when_maul_is_performed();
+
+    // [Damage] = (([min - max] + AP / 14) + bonus_damage) * 1.1
+    // [477 - 544] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14) + 128
+    then_damage_dealt_is_in_range(477, 544);
+}
+
+void TestMaul::test_hit_dmg_2_of_2_savage_fury() {
+    given_feral_talent_rank("Savage Fury", 2);
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    given_druid_in_bear_form();
+    given_1000_melee_ap();
+    given_druid_has_rage(100);
+    given_a_guaranteed_melee_ability_hit();
+    given_engine_priority_at(0.51);
+
+    when_maul_is_performed();
+
+    // [Damage] = ([min - max] + AP / 14) + bonus_damage
+    // [520 - 594] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14) + 128
+    then_damage_dealt_is_in_range(520, 594);
+}
+
+void TestMaul::test_hit_dmg() {
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    given_druid_in_bear_form();
+    given_1000_melee_ap();
+    given_druid_has_rage(100);
+    given_a_guaranteed_melee_ability_hit();
+    given_engine_priority_at(0.51);
+
+    when_maul_is_performed();
+
+    // [Damage] = ([min - max] + AP / 14) + bonus_damage
+    // [434 - 495] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14) + 128
+    then_damage_dealt_is_in_range(434, 495);
+}
+
+void TestMaul::test_hit_threat() {
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    given_druid_in_bear_form();
+    given_1000_melee_ap();
+    given_druid_has_rage(100);
+    given_a_guaranteed_melee_ability_hit();
+    given_engine_priority_at(0.51);
+
+    when_maul_is_performed();
+
+    // [Damage] = ([min - max] + AP / 14) + bonus_damage
+    // [434 - 495] = 2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14) + 128
+    then_damage_dealt_is_in_range(434, 495);
+
+    // [Threat] = [Damage*1.75*1.3] = [987 - 1127]
+    then_threat_dealt_is_in_range(987, 1127);
+}
+
+void TestMaul::test_crit_dmg() {
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    given_druid_in_bear_form();
+    given_1000_melee_ap();
+    given_druid_has_rage(100);
+    given_a_guaranteed_melee_ability_crit();
+    given_engine_priority_at(0.51);
+
+    when_maul_is_performed();
+
+    // [Damage] = (([min - max] + AP / 14) + bonus_damage) * crit_dmg_modifier
+    // [868 - 1019] = (2.5 * ([60 * 0.85 - 60 * 1.25] + 1000 / 14) + 128) * 2.0
+    then_damage_dealt_is_in_range(868, 990);
+}
+
+void TestMaul::when_maul_is_performed() {
+    maul()->calculate_damage();
+}
+
+void TestMaul::given_druid_in_bear_form() {
+    bear_form()->perform();
+}

--- a/Test/Druid/Spells/TestMaul.h
+++ b/Test/Druid/Spells/TestMaul.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "TestSpellDruid.h"
+
+class TestMaul : public TestSpellDruid {
+public:
+    TestMaul(EquipmentDb* equipment_db);
+
+    void test_all();
+
+private:
+    void test_name_correct() override;
+    void test_spell_cooldown() override;
+    void test_whether_spell_causes_global_cooldown() override;
+    void test_how_spell_observes_global_cooldown() override;
+    void test_resource_cost() override;
+    void test_is_ready_conditions() override;
+    void test_resource_cost_1_of_5_ferocity();
+    void test_resource_cost_2_of_5_ferocity();
+    void test_resource_cost_3_of_5_ferocity();
+    void test_resource_cost_4_of_5_ferocity();
+    void test_resource_cost_5_of_5_ferocity();
+    void test_hit_dmg_1_of_2_savage_fury();
+    void test_hit_dmg_2_of_2_savage_fury();
+    void test_hit_dmg();
+    void test_hit_threat();
+    void test_crit_dmg();
+
+    void given_druid_in_bear_form();
+    void when_maul_is_performed();
+};

--- a/Test/Druid/Spells/TestSwipe.cpp
+++ b/Test/Druid/Spells/TestSwipe.cpp
@@ -1,0 +1,280 @@
+#include "TestSwipe.h"
+
+#include <cassert>
+
+#include "Buff.h"
+#include "Druid.h"
+#include "DruidSpells.h"
+#include "Swipe.h"
+#include "bearForm.h"
+
+TestSwipe::TestSwipe(EquipmentDb* equipment_db) : TestSpellDruid(equipment_db, "Swipe") {}
+
+void TestSwipe::test_all() {
+    run_mandatory_tests();
+
+    set_up();
+    test_resource_cost_1_of_5_ferocity();
+    tear_down();
+
+    set_up();
+    test_resource_cost_2_of_5_ferocity();
+    tear_down();
+
+    set_up();
+    test_resource_cost_3_of_5_ferocity();
+    tear_down();
+
+    set_up();
+    test_resource_cost_4_of_5_ferocity();
+    tear_down();
+
+    set_up();
+    test_resource_cost_5_of_5_ferocity();
+    tear_down();
+
+    set_up();
+    test_hit_dmg();
+    tear_down();
+
+    set_up();
+    test_crit_dmg();
+    tear_down();
+
+    set_up();
+    test_swipe_hit_with_0_of_2_primal_fury_awards_0_rage();
+    tear_down();
+
+    set_up();
+    test_swipe_crit_with_0_of_2_primal_fury_awards_0_rage();
+    tear_down();
+
+    set_up();
+    test_swipe_hit_with_2_of_2_primal_fury_awards_0_rage();
+    tear_down();
+
+    set_up();
+    test_swipe_crit_with_2_of_2_primal_fury_awards_5_rage();
+    tear_down();
+}
+
+void TestSwipe::test_name_correct() {
+    assert(swipe()->get_name() == "Swipe");
+}
+
+void TestSwipe::test_spell_cooldown() {
+    assert(almost_equal(0.0, swipe()->get_base_cooldown()));
+}
+
+void TestSwipe::test_whether_spell_causes_global_cooldown() {
+    given_druid_in_bear_form();
+    given_engine_priority_at(0.51);
+    given_druid_has_rage(100);
+    assert(druid->action_ready());
+
+    when_swipe_is_performed();
+
+    assert(!druid->action_ready());
+}
+
+void TestSwipe::test_how_spell_observes_global_cooldown() {}
+
+void TestSwipe::test_resource_cost() {
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_druid_has_rage(100);
+    given_engine_priority_at(0.51);
+
+    when_swipe_is_performed();
+
+    then_druid_has_rage(80);
+}
+
+void TestSwipe::test_is_ready_conditions() {
+    assert(swipe()->get_spell_status() == SpellStatus::InsufficientResources);
+
+    given_druid_in_bear_form();
+    given_engine_priority_at(0.51);
+
+    assert(swipe()->get_spell_status() == SpellStatus::InsufficientResources);
+
+    given_druid_has_rage(100);
+
+    assert(swipe()->get_spell_status() == SpellStatus::Available);
+}
+
+void TestSwipe::test_resource_cost_1_of_5_ferocity() {
+    given_feral_talent_rank("Ferocity", 1);
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_druid_has_rage(100);
+    given_engine_priority_at(0.51);
+
+    when_swipe_is_performed();
+
+    then_druid_has_rage(81);
+}
+
+void TestSwipe::test_resource_cost_2_of_5_ferocity() {
+    given_feral_talent_rank("Ferocity", 2);
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_druid_has_rage(100);
+    given_engine_priority_at(0.51);
+
+    when_swipe_is_performed();
+
+    then_druid_has_rage(82);
+}
+
+void TestSwipe::test_resource_cost_3_of_5_ferocity() {
+    given_feral_talent_rank("Ferocity", 3);
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_druid_has_rage(100);
+    given_engine_priority_at(0.51);
+
+    when_swipe_is_performed();
+
+    then_druid_has_rage(83);
+}
+
+void TestSwipe::test_resource_cost_4_of_5_ferocity() {
+    given_feral_talent_rank("Ferocity", 4);
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_druid_has_rage(100);
+    given_engine_priority_at(0.51);
+
+    when_swipe_is_performed();
+
+    then_druid_has_rage(84);
+}
+
+void TestSwipe::test_resource_cost_5_of_5_ferocity() {
+    given_feral_talent_rank("Ferocity", 5);
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_druid_has_rage(100);
+    given_engine_priority_at(0.51);
+
+    when_swipe_is_performed();
+
+    then_druid_has_rage(85);
+}
+
+void TestSwipe::test_hit_dmg_1_of_2_savage_fury() {
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    given_druid_in_bear_form();
+    given_1000_melee_ap();
+    given_a_guaranteed_melee_ability_hit();
+    given_engine_priority_at(0.51);
+    given_druid_has_rage(100);
+
+    when_swipe_is_performed();
+
+    // [Damage] = bonus_damage * 1.1 = 91.3
+    then_damage_dealt_is_in_range(91, 92);
+}
+
+void TestSwipe::test_hit_dmg_2_of_2_savage_fury() {
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    given_druid_in_bear_form();
+    given_1000_melee_ap();
+    given_a_guaranteed_melee_ability_hit();
+    given_engine_priority_at(0.51);
+    given_druid_has_rage(100);
+
+    when_swipe_is_performed();
+
+    // [Damage] = bonus_damage = 99.6
+    then_damage_dealt_is_in_range(99, 100);
+}
+
+void TestSwipe::test_hit_dmg() {
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    given_druid_in_bear_form();
+    given_1000_melee_ap();
+    given_a_guaranteed_melee_ability_hit();
+    given_engine_priority_at(0.51);
+    given_druid_has_rage(100);
+
+    when_swipe_is_performed();
+
+    // [Damage] = bonus_damage = 83
+    then_damage_dealt_is_in_range(82, 84);
+}
+
+void TestSwipe::test_crit_dmg() {
+    given_target_has_0_armor();
+    given_in_melee_attack_mode();
+    given_druid_in_bear_form();
+    given_1000_melee_ap();
+    given_a_guaranteed_melee_ability_crit();
+    given_engine_priority_at(0.51);
+    given_druid_has_rage(100);
+
+    when_swipe_is_performed();
+
+    // [Damage] = bonus_damage * crit_dmg_modifier = 83*2 = 166
+    then_damage_dealt_is_in_range(165, 167);
+}
+
+void TestSwipe::test_swipe_hit_with_0_of_2_primal_fury_awards_0_rage() {
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_crit();
+    given_engine_priority_at(0.51);
+    given_druid_has_rage(100);
+
+    when_swipe_is_performed();
+
+    then_druid_has_rage(80);
+}
+
+void TestSwipe::test_swipe_crit_with_0_of_2_primal_fury_awards_0_rage() {
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_crit();
+    given_engine_priority_at(0.51);
+    given_druid_has_rage(100);
+
+    when_swipe_is_performed();
+
+    then_druid_has_rage(80);
+}
+
+void TestSwipe::test_swipe_hit_with_2_of_2_primal_fury_awards_0_rage() {
+    given_feral_talent_ranks({{"Sharpened Claws", 3}, {"Primal Fury", 2}});
+    pchar->prepare_set_of_combat_iterations();
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_hit();
+    given_engine_priority_at(0.51);
+    given_druid_has_rage(100);
+
+    when_swipe_is_performed();
+
+    then_druid_has_rage(80);
+}
+
+void TestSwipe::test_swipe_crit_with_2_of_2_primal_fury_awards_5_rage() {
+    given_feral_talent_ranks({{"Sharpened Claws", 3}, {"Primal Fury", 2}});
+    pchar->prepare_set_of_combat_iterations();
+    given_druid_in_bear_form();
+    given_a_guaranteed_melee_ability_crit();
+    given_engine_priority_at(0.51);
+    given_druid_has_rage(100);
+
+    when_swipe_is_performed();
+
+    then_druid_has_rage(85);
+}
+
+void TestSwipe::when_swipe_is_performed() {
+    swipe()->perform();
+}
+
+void TestSwipe::given_druid_in_bear_form() {
+    bear_form()->perform();
+}

--- a/Test/Druid/Spells/TestSwipe.h
+++ b/Test/Druid/Spells/TestSwipe.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "TestSpellDruid.h"
+
+class TestSwipe : public TestSpellDruid {
+public:
+    TestSwipe(EquipmentDb* equipment_db);
+
+    void test_all();
+
+private:
+    void test_name_correct() override;
+    void test_spell_cooldown() override;
+    void test_whether_spell_causes_global_cooldown() override;
+    void test_how_spell_observes_global_cooldown() override;
+    void test_resource_cost() override;
+    void test_is_ready_conditions() override;
+    void test_resource_cost_1_of_5_ferocity();
+    void test_resource_cost_2_of_5_ferocity();
+    void test_resource_cost_3_of_5_ferocity();
+    void test_resource_cost_4_of_5_ferocity();
+    void test_resource_cost_5_of_5_ferocity();
+    void test_hit_dmg_1_of_2_savage_fury();
+    void test_hit_dmg_2_of_2_savage_fury();
+    void test_hit_dmg();
+    void test_crit_dmg();
+    void test_swipe_hit_with_0_of_2_primal_fury_awards_0_rage();
+    void test_swipe_crit_with_0_of_2_primal_fury_awards_0_rage();
+    void test_swipe_hit_with_2_of_2_primal_fury_awards_0_rage();
+    void test_swipe_crit_with_2_of_2_primal_fury_awards_5_rage();
+
+    void given_druid_in_bear_form();
+    void when_swipe_is_performed();
+};

--- a/Test/Druid/TestDruid.cpp
+++ b/Test/Druid/TestDruid.cpp
@@ -18,6 +18,9 @@
 #include "TestShred.h"
 #include "TestStarfire.h"
 #include "TestWrath.h"
+#include "TestBearForm.h"
+#include "TestMaul.h"
+#include "TestSwipe.h"
 
 TestDruid::TestDruid(EquipmentDb* equipment_db) : TestObject(equipment_db) {}
 
@@ -35,6 +38,9 @@ void TestDruid::test_all() {
     TestCatForm(equipment_db).test_all();
     TestShred(equipment_db).test_all();
     TestFerociousBite(equipment_db).test_all();
+    TestBearForm(equipment_db).test_all();
+    TestMaul(equipment_db).test_all();
+    TestSwipe(equipment_db).test_all();
 }
 
 void TestDruid::test_values_after_initialization() {

--- a/Test/Druid/TestSpellDruid.cpp
+++ b/Test/Druid/TestSpellDruid.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "Balance.h"
+#include "BearForm.h"
 #include "Buff.h"
 #include "CatForm.h"
 #include "CharacterStats.h"
@@ -13,6 +14,7 @@
 #include "FeralCombat.h"
 #include "FerociousBite.h"
 #include "Item.h"
+#include "Maul.h"
 #include "Moonfire.h"
 #include "MoonkinForm.h"
 #include "RaidControl.h"
@@ -21,6 +23,7 @@
 #include "SimSettings.h"
 #include "Spell.h"
 #include "Starfire.h"
+#include "Swipe.h"
 #include "Talent.h"
 #include "Wrath.h"
 
@@ -66,8 +69,20 @@ CatForm* TestSpellDruid::cat_form() const {
     return static_cast<CatForm*>(get_max_rank_spell_by_name("Cat Form"));
 }
 
+BearForm* TestSpellDruid::bear_form() const {
+    return static_cast<BearForm*>(get_max_rank_spell_by_name("Bear Form"));
+}
+
 Shred* TestSpellDruid::shred() const {
     return static_cast<Shred*>(get_max_rank_spell_by_name("Shred"));
+}
+
+Swipe* TestSpellDruid::swipe() const {
+    return static_cast<Swipe*>(get_max_rank_spell_by_name("Swipe"));
+}
+
+Maul* TestSpellDruid::maul() const {
+    return static_cast<Maul*>(get_max_rank_spell_by_name("Maul"));
 }
 
 FerociousBite* TestSpellDruid::ferocious_bite() const {
@@ -136,6 +151,13 @@ void TestSpellDruid::given_druid_has_energy(const unsigned energy) {
     then_druid_has_energy(energy);
 }
 
+void TestSpellDruid::given_druid_has_rage(const unsigned rage) {
+    if (druid->get_resource_level(ResourceType::Rage) > 0)
+        druid->lose_energy(druid->get_resource_level(ResourceType::Rage));
+    druid->gain_rage(rage);
+    then_druid_has_rage(rage);
+}
+
 void TestSpellDruid::then_druid_has_mana(const unsigned mana) {
     if (mana != druid->get_resource_level(ResourceType::Mana))
         qDebug() << "Expected" << mana << "mana but has" << druid->get_resource_level(ResourceType::Mana);
@@ -146,4 +168,10 @@ void TestSpellDruid::then_druid_has_energy(const unsigned energy) {
     if (energy != druid->get_resource_level(ResourceType::Energy))
         qDebug() << "Expected" << energy << "energy but has" << druid->get_resource_level(ResourceType::Energy);
     assert(druid->get_resource_level(ResourceType::Energy) == energy);
+}
+
+void TestSpellDruid::then_druid_has_rage(const unsigned rage) {
+    if (rage != druid->get_resource_level(ResourceType::Rage))
+        qDebug() << "Expected" << rage << "rage but has" << druid->get_resource_level(ResourceType::Rage);
+    assert(druid->get_resource_level(ResourceType::Rage) == rage);
 }

--- a/Test/Druid/TestSpellDruid.h
+++ b/Test/Druid/TestSpellDruid.h
@@ -6,11 +6,15 @@ class CatForm;
 class Druid;
 class Moonfire;
 class MoonkinForm;
+class BearForm;
+class Maul;
 class Shred;
+class Swipe;
 class Spell;
 class Starfire;
 class Wrath;
 class FerociousBite;
+class Enrage;
 
 class TestSpellDruid : public TestSpellDamage {
 public:
@@ -29,8 +33,12 @@ protected:
     Starfire* starfire() const;
     MoonkinForm* moonkin_form() const;
     CatForm* cat_form() const;
+    BearForm* bear_form() const;
     Shred* shred() const;
+    Swipe* swipe() const;
+    Maul* maul() const;
     FerociousBite* ferocious_bite() const;
+    Enrage* enrage() const;
 
     void given_balance_talent_rank(const QString& talent_name, const unsigned num);
     void given_feral_talent_rank(const QString& talent_name, const unsigned num);
@@ -40,8 +48,10 @@ protected:
     void given_druid_has_combo_points(const unsigned num);
     void given_druid_has_mana(const unsigned mana);
     void given_druid_has_energy(const unsigned energy);
+    void given_druid_has_rage(const unsigned rage);
     void given_druid_is_on_gcd(Spell* spell);
 
     void then_druid_has_mana(const unsigned mana);
     void then_druid_has_energy(const unsigned energy);
+    void then_druid_has_rage(const unsigned rage);
 };

--- a/Test/TestSpell.cpp
+++ b/Test/TestSpell.cpp
@@ -1103,6 +1103,13 @@ void TestSpell::then_damage_dealt_is(const int damage) {
     assert(pchar->get_statistics()->get_total_personal_damage_dealt() == damage);
 }
 
+void TestSpell::then_threat_dealt_is(const int threat) {
+    if (threat != pchar->get_statistics()->get_total_personal_threat_dealt())
+        qDebug() << spell_under_test << "then_threat_dealt_is() assertion failed, expected" << threat << "got"
+                 << pchar->get_statistics()->get_total_personal_threat_dealt();
+    assert(pchar->get_statistics()->get_total_personal_threat_dealt() == threat);
+}
+
 void TestSpell::then_damage_dealt_is_in_range(const int min, const int max) {
     assert(min < max);
     const int damage_dealt = pchar->get_statistics()->get_total_personal_damage_dealt();
@@ -1111,6 +1118,16 @@ void TestSpell::then_damage_dealt_is_in_range(const int min, const int max) {
         qDebug() << spell_under_test << "then_damage_dealt_is_in_range() assertion failed, expected range" << min << "-" << max << "but got"
                  << damage_dealt;
     assert(damage_dealt >= min && damage_dealt <= max);
+}
+
+void TestSpell::then_threat_dealt_is_in_range(const int min, const int max) {
+    assert(min < max);
+    const int threat_dealt = pchar->get_statistics()->get_total_personal_threat_dealt();
+
+    if (threat_dealt < min || threat_dealt > max)
+        qDebug() << spell_under_test << "then_threat_dealt_is_in_range() assertion failed, expected range" << min << "-" << max << "but got"
+                 << threat_dealt;
+    assert(threat_dealt >= min && threat_dealt <= max);
 }
 
 void TestSpell::then_next_event_is(const EventType event_type) {

--- a/Test/TestSpell.h
+++ b/Test/TestSpell.h
@@ -126,6 +126,8 @@ public:
 
     void then_damage_dealt_is(const int damage);
     void then_damage_dealt_is_in_range(const int min, const int max);
+    void then_threat_dealt_is(const int damage);
+    void then_threat_dealt_is_in_range(const int min, const int max);
     void then_next_event_is(const EventType event_type);
     void then_next_event_is(const EventType event_type, const QString& priority, bool act_event = false);
     void then_resource_is(const ResourceType resource_type, const unsigned expected);

--- a/qml.qrc
+++ b/qml.qrc
@@ -963,6 +963,8 @@
         <file>QML/Assets/ability/Ability_racial_cannibalize.png</file>
         <file>QML/Assets/spell/Spell_holy_blessingofagility.png</file>
         <file>QML/Assets/ability/Ability_druid_enrage.png</file>
+        <file>QML/Assets/ability/Ability_druid_maul.png</file>
+        <file>QML/Assets/ability/Ability_druid_swipe.png</file>
         <file>QML/Assets/items/Inv_relics_idolofrejuvenation.png</file>
         <file>QML/Assets/spell/Spell_holy_elunesgrace.png</file>
         <file>QML/Assets/spell/Spell_nature_healingwavegreater.png</file>


### PR DESCRIPTION
I implemented bear dps:

- Maul
- Swipe
- Enrage
- Talents: Primal Fury, Savage Fury, Feral Instinct, Furor, Ferocity, Improved Enrage
- Tank rotation

and threat is calculated properly for:

Bear form 1.3 multiplicator
Feral Instinct additive increase of up to 0.15 (-> 5/5 results in a bear form multiplicator of 1.45)
Maul and Swipe multiplicator of 1.75

Added Item Molten Belt, Defilers/Highlanders set, Thick Qirajihide Belt and Blooddrenched Leggings.

There are tests for everything I added.
