### PR TITLE
Remove SimulationRunner::finished()

### DIFF
--- a/Thread/SimulationRunner.cpp
+++ b/Thread/SimulationRunner.cpp
@@ -28,7 +28,6 @@ SimulationRunner::SimulationRunner(
 
 void SimulationRunner::run_sim(unsigned thread_id, QVector<QString> setup_strings, bool full_sim, int iterations) {
     if (this->thread_id != thread_id) {
-        emit finished();
         return;
     }
 
@@ -87,7 +86,6 @@ void SimulationRunner::run_sim(unsigned thread_id, QVector<QString> setup_string
     delete raid_control;
 
     emit result();
-    emit finished();
 }
 
 void SimulationRunner::receive_progress(const int iterations_completed) {
@@ -103,5 +101,4 @@ void SimulationRunner::exit_thread(QString err) {
     delete local_sim_settings;
     delete raid_control;
     emit error(QString::number(thread_id), std::move(err));
-    emit finished();
 }

--- a/Thread/SimulationRunner.h
+++ b/Thread/SimulationRunner.h
@@ -34,7 +34,6 @@ public slots:
     void receive_progress(const int iterations_completed);
 
 signals:
-    void finished();
     void result();
     void error(QString seed, QString err);
     void update_progress(const int iterations_completed);

--- a/Thread/SimulationThreadPool.cpp
+++ b/Thread/SimulationThreadPool.cpp
@@ -97,7 +97,6 @@ void SimulationThreadPool::setup_thread(const unsigned thread_id) {
     connect(runner, SIGNAL(error(QString, QString)), this, SLOT(error_string(QString, QString)));
     connect(runner, SIGNAL(result()), this, SLOT(thread_finished()));
     connect(runner, SIGNAL(update_progress(const int)), this, SLOT(increase_iterations_completed(int)));
-    connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
 
     thread_pool.append(QPair<unsigned, QThread*>(thread_id, thread));
     active_thread_ids.append(thread_id);


### PR DESCRIPTION
It's not hooked up to anything, no reason to have it around.

I'm not even sure how this compiles TBH.