### PR TITLE
Rename SimulationRunner::result to simulation_runner_has_result

### DIFF
--- a/Thread/SimulationRunner.cpp
+++ b/Thread/SimulationRunner.cpp
@@ -86,7 +86,7 @@ void SimulationRunner::sim_runner_run(unsigned thread_id, QVector<QString> setup
     delete local_sim_settings;
     delete raid_control;
 
-    emit result();
+    emit simulation_runner_has_result();
     emit finished();
 }
 

--- a/Thread/SimulationRunner.h
+++ b/Thread/SimulationRunner.h
@@ -35,7 +35,7 @@ public slots:
 
 signals:
     void finished();
-    void result();
+    void simulation_runner_has_result();
     void error(QString seed, QString err);
     void update_progress(const int iterations_completed);
 

--- a/Thread/SimulationThreadPool.cpp
+++ b/Thread/SimulationThreadPool.cpp
@@ -95,7 +95,7 @@ void SimulationThreadPool::setup_thread(const unsigned thread_id) {
 
     connect(this, SIGNAL(start_simulation(uint, QVector<QString>, bool, int)), runner, SLOT(sim_runner_run(uint, QVector<QString>, bool, int)));
     connect(runner, SIGNAL(error(QString, QString)), this, SLOT(error_string(QString, QString)));
-    connect(runner, SIGNAL(result()), this, SLOT(thread_finished()));
+    connect(runner, SIGNAL(simulation_runner_has_result()), this, SLOT(thread_finished()));
     connect(runner, SIGNAL(update_progress(const int)), this, SLOT(increase_iterations_completed(int)));
     connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
 


### PR DESCRIPTION
The only mechanism to find the connection for a signal is grep and
`result` has ~750 usages in this codebase. For simplicity, rename it to
a trivially grepable term.