### PR TITLE
Rename SimRunner::run_sum to sim_runner_run

### DIFF
--- a/Thread/SimulationRunner.cpp
+++ b/Thread/SimulationRunner.cpp
@@ -26,7 +26,7 @@ SimulationRunner::SimulationRunner(
     full_sim(false),
     thread_id(thread_id) {}
 
-void SimulationRunner::run_sim(unsigned thread_id, QVector<QString> setup_strings, bool full_sim, int iterations) {
+void SimulationRunner::sim_runner_run(unsigned thread_id, QVector<QString> setup_strings, bool full_sim, int iterations) {
     if (this->thread_id != thread_id) {
         emit finished();
         return;

--- a/Thread/SimulationRunner.h
+++ b/Thread/SimulationRunner.h
@@ -30,7 +30,7 @@ public:
     ~SimulationRunner() = default;
 
 public slots:
-    void run_sim(unsigned thread_id, QVector<QString> setup_strings, bool full_sim, int iterations);
+    void sim_runner_run(unsigned thread_id, QVector<QString> setup_strings, bool full_sim, int iterations);
     void receive_progress(const int iterations_completed);
 
 signals:

--- a/Thread/SimulationThreadPool.cpp
+++ b/Thread/SimulationThreadPool.cpp
@@ -93,7 +93,7 @@ void SimulationThreadPool::setup_thread(const unsigned thread_id) {
     auto runner = new SimulationRunner(thread_id, equipment_db, random_affixes, sim_settings, scaler);
     auto thread = new QThread(runner);
 
-    connect(this, SIGNAL(start_simulation(uint, QVector<QString>, bool, int)), runner, SLOT(run_sim(uint, QVector<QString>, bool, int)));
+    connect(this, SIGNAL(start_simulation(uint, QVector<QString>, bool, int)), runner, SLOT(sim_runner_run(uint, QVector<QString>, bool, int)));
     connect(runner, SIGNAL(error(QString, QString)), this, SLOT(error_string(QString, QString)));
     connect(runner, SIGNAL(result()), this, SLOT(thread_finished()));
     connect(runner, SIGNAL(update_progress(const int)), this, SLOT(increase_iterations_completed(int)));


### PR DESCRIPTION
run_sim is a very overloaded term in this codebase around seven-ish
different versions existing across five-ish different classes. Given
that signals/slots require `grep`, we can rename this member func to
give it a unique name.