### PR TITLE
better error msg when equipment_paths.xml missing

### DIFF
--- a/Equipment/EquipmentDb/EquipmentDb.cpp
+++ b/Equipment/EquipmentDb/EquipmentDb.cpp
@@ -304,8 +304,8 @@ void EquipmentDb::read_equipment_files() {
     QFile file("equipment_paths.xml");
 
     if (!file.open(QFile::ReadOnly | QFile::Text)) {
-        qDebug() << "Cannot read file:" << file.errorString();
-        qDebug() << QDir::currentPath();
+        qDebug() << "Error opening" << file.fileName() << "in" << QDir::currentPath();
+        qDebug() << file.errorString();
         exit(0);
     }
 

--- a/Equipment/EquipmentDb/EquipmentDb.cpp
+++ b/Equipment/EquipmentDb/EquipmentDb.cpp
@@ -305,7 +305,9 @@ void EquipmentDb::read_equipment_files() {
 
     if (!file.open(QFile::ReadOnly | QFile::Text)) {
         qDebug() << "Error opening" << file.fileName() << "in" << QDir::currentPath();
-        qDebug() << file.errorString();
+        qDebug() << file.errorString() << "\n";
+        qDebug() << "Verify the paths in 'build.config' are correct and run 'DevTools/copy_to_debug.py'.";
+        qDebug() << "For more information see: https://github.com/timhul/ClassicSim/wiki/Developer-Information";
         exit(0);
     }
 


### PR DESCRIPTION
If the user makes a mistake setting up their build environment they might receive this error when running:

"The system cannot find the file specified."

But the error doesn't say which file it can't find. 