### PR TITLE
Add items from moonkin spreadsheet

### DIFF
--- a/Equipment/EquipmentDb/Belts/leather.xml
+++ b/Equipment/EquipmentDb/Belts/leather.xml
@@ -93,6 +93,20 @@
 		</source>
 	</item>
 
+	<item id="19134" phase="2">
+		<info name="Flayed Doomguard Belt" type="LEATHER" slot="BELT" unique="no" req_lvl="60" item_lvl="68" quality="EPIC" boe="no" icon="Inv_belt_16.png"/>
+		<stats>
+			<stat type="ARMOR" value="115"/>
+			<stat type="STAMINA" value="18"/>
+			<stat type="INTELLECT" value="18"/>
+			<stat type="SPELL_DAMAGE" value="14"/>
+			<stat type="SPELL_CRIT_CHANCE" value="0.01"/>
+		</stats>
+		<source>
+			Drops from World Boss Kazzak in Blasted Lands.
+		</source>
+	</item>
+
 	<item id="19396" phase="3">
 		<info name="Taut Dragonhide Belt" type="LEATHER" slot="BELT" unique="no" req_lvl="60" item_lvl="75" quality="EPIC" boe="no" icon="Inv_belt_16.png"/>
 		<stats>

--- a/Equipment/EquipmentDb/Boots/leather.xml
+++ b/Equipment/EquipmentDb/Boots/leather.xml
@@ -102,6 +102,19 @@
 		</source>
 	</item>
 
+	<item id="18322" phase="2">
+		<info name="Waterspout Boots" type="LEATHER" slot="BOOTS" unique="no" req_lvl="53" item_lvl="58" quality="RARE" boe="no" icon="Inv_boots_08.png"/>
+		<stats>
+			<stat type="ARMOR" value="114"/>
+			<stat type="INTELLECT" value="6"/>
+			<stat type="SPIRIT" value="6"/>
+			<stat type="SPELL_DAMAGE" value="25"/>
+		</stats>
+		<source>
+			Drops from Hydrospawn in Dire Maul: East.
+		</source>
+	</item>
+
 	<item id="16906" phase="3">
 		<info name="Bloodfang Boots" type="LEATHER" slot="BOOTS" unique="no" req_lvl="60" item_lvl="76" quality="EPIC" boe="no" icon="Inv_boots_08.png"/>
 		<class_restriction class="ROGUE"/>

--- a/Equipment/EquipmentDb/Gloves/leather.xml
+++ b/Equipment/EquipmentDb/Gloves/leather.xml
@@ -238,6 +238,18 @@
 		</source>
 	</item>
 
+	<item id="21178" phase="5">
+		<info name="Gloves of Earthen Power" type="LEATHER" slot="GLOVES" unique="no" req_lvl="0" item_lvl="62" quality="RARE" boe="no" icon="Inv_gauntlets_18.png"/>
+		<stats>
+			<stat type="ARMOR" value="109"/>
+			<stat type="INTELLECT" value="9"/>
+			<stat type="SPELL_DAMAGE" value="27"/>
+		</stats>
+		<source>
+			Reward from Silithus Quest: Volunteer's Battlegear
+		</source>
+	</item>
+
 	<item id="22481" phase="6">
 		<info name="Bonescythe Gauntlets" type="LEATHER" slot="GLOVES" unique="no" req_lvl="60" item_lvl="88" quality="EPIC" boe="no" icon="Inv_gauntlets_28.png"/>
 		<class_restriction class="ROGUE"/>

--- a/Equipment/EquipmentDb/Misc/backs.xml
+++ b/Equipment/EquipmentDb/Misc/backs.xml
@@ -132,6 +132,19 @@
 		</source>
 	</item>
 
+	<item id="20697" phase="4">
+		<info name="Crystalline Threaded Cape" type="CLOTH" slot="BACK" unique="no" req_lvl="58" item_lvl="63" quality="RARE" boe="yes" icon="Inv_misc_cape_19.png"/>
+		<stats>
+			<stat type="ARMOR" value="45"/>
+			<stat type="STAMINA" value="5"/>
+			<stat type="INTELLECT" value="4"/>
+			<stat type="SPELL_DAMAGE" value="20"/>
+		</stats>
+		<source>
+			Contained in 'Sack of Spoils' reward from Silithus quests "Signet of the Dukes" and "Abyssal Signets"
+		</source>
+	</item>
+
 	<item id="18204" phase="2">
 		<info name="Eskhandar's Pelt" type="CLOTH" slot="BACK" unique="no" req_lvl="60" item_lvl="66" quality="EPIC" boe="no" icon="Inv_misc_cape_07.png"/>
 		<stats>

--- a/Equipment/EquipmentDb/Misc/rings.xml
+++ b/Equipment/EquipmentDb/Misc/rings.xml
@@ -521,6 +521,18 @@
 		</source>
 	</item>
 
+	<item id="20682" phase="4">
+		<info name="Elemental Focus Band" type="RING" slot="RING" unique="yes" req_lvl="60" item_lvl="65" quality="EPIC" boe="no" icon="Inv_jewelry_ring_23.png"/>
+		<stats>
+			<stat type="STAMINA" value="8"/>
+			<stat type="INTELLECT" value="11"/>
+			<stat type="SPELL_DAMAGE" value="22"/>
+		</stats>
+		<source>
+			Dropped by Prince Skaldrenox in Silithus.
+		</source>
+	</item>
+
 	<item id="22255" phase="5">
 		<info name="Magma Forged Band" type="RING" slot="RING" unique="yes" req_lvl="52" item_lvl="57" quality="RARE" boe="no" icon="Inv_jewelry_ring_04.png"/>
 		<stats>
@@ -758,6 +770,18 @@
 		</source>
 	</item>
 
+	<item id="22339" phase="5">
+		<info name="Rune Band of Wizardry" type="RING" slot="RING" unique="yes" req_lvl="58" item_lvl="63" quality="RARE" boe="no" icon="Inv_jewelry_ring_35.png"/>
+		<stats>
+			<stat type="STAMINA" value="7"/>
+			<stat type="SPELL_DAMAGE" value="16"/>
+			<stat type="SPELL_HIT_CHANCE" value="0.01"/>
+		</stats>
+		<source>
+			Drops from Lord Valthalak in Blackrock Spire.
+		</source>
+	</item>
+
 	<item id="23237" phase="6">
 		<info name="Ring of the Eternal Flame" type="RING" slot="RING" unique="yes" req_lvl="60" item_lvl="83" quality="EPIC" boe="no" icon="Inv_jewelry_ring_48naxxramas.png"/>
 		<stats>
@@ -854,6 +878,17 @@
 		</stats>
 		<source>
 			Drops from Kel'Thuzad in Naxxramas.
+		</source>
+	</item>
+
+	<item id="23031" phase="6">
+		<info name="Band of the Inevitable" type="RING" slot="RING" unique="yes" req_lvl="60" item_lvl="83" quality="EPIC" boe="no" icon="Inv_jewelry_ring_53naxxramas.png"/>
+		<stats>
+			<stat type="SPELL_DAMAGE" value="36"/>
+			<stat type="SPELL_HIT_CHANCE" value="0.01"/>
+		</stats>
+		<source>
+			Dropped from Noth the Plaguebringer in Naxxramas.
 		</source>
 	</item>
 </items>

--- a/Equipment/EquipmentDb/Misc/rings.xml
+++ b/Equipment/EquipmentDb/Misc/rings.xml
@@ -533,6 +533,18 @@
 		</source>
 	</item>
 
+	<item id="22721" phase="4">
+		<info name="Band of Servitude" type="RING" slot="RING" unique="yes" req_lvl="60" item_lvl="65" quality="EPIC" boe="no" icon="Inv_jewelry_ring_16.png"/>
+		<stats>
+			<stat type="STAMINA" value="8"/>
+			<stat type="INTELLECT" value="9"/>
+			<stat type="SPELL_DAMAGE" value="23"/>
+		</stats>
+		<source>
+			Drops from High Priest bosses in Zul'Gurub.
+		</source>
+	</item>
+
 	<item id="22255" phase="5">
 		<info name="Magma Forged Band" type="RING" slot="RING" unique="yes" req_lvl="52" item_lvl="57" quality="RARE" boe="no" icon="Inv_jewelry_ring_04.png"/>
 		<stats>

--- a/Equipment/EquipmentDb/Weapons/1hDaggers.xml
+++ b/Equipment/EquipmentDb/Weapons/1hDaggers.xml
@@ -183,6 +183,19 @@
 		</source>
 	</melee_weapon>
 
+	<melee_weapon id="20214" phase="3">
+		<info name="Mindfang" type="DAGGER" slot="1H" unique="no" req_lvl="60" item_lvl="65" quality="EPIC" boe="no" icon="Inv_sword_13.png"/>
+		<stats>
+			<stat type="ARMOR" value="35"/>
+			<stat type="STAMINA" value="8"/>
+			<stat type="SPELL_DAMAGE" value="30"/>
+			<stat type="SPELL_CRIT_CHANCE" value="0.01"/>
+		</stats>
+		<source>
+			Requires The Defilers - Exalted
+		</source>
+	</melee_weapon>
+
 	<melee_weapon id="17070" phase="4">
 		<info name="Fang of the Mystics" type="DAGGER" slot="1H" unique="no" req_lvl="60" item_lvl="70" quality="EPIC" boe="no" icon="Inv_weapon_shortblade_06.png"/>
 		<dmg_range min="39" max="86" speed="1.5"/>


### PR DESCRIPTION
These are items available on the balance druid spreadsheet that are missing from ClassicSim.

- Waterspout Boots
- Crystalline Threaded Cape
- Mindfang
- Elemental Focus Band
- Band of the Inevitable
- Band of Servitude
- Rune Band of Wizardry
- Flayed Doomguard Belt
- Gloves of Earthen Power