### PR TITLE
Missing images from #261

### DIFF
--- a/QML/Assets/items/Inv_gauntlets_18.png
+++ b/QML/Assets/items/Inv_gauntlets_18.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d8ca20150a93a7abffe08b7c4c2b3778bb9c1142017e8240b8199cef91e860c
+size 5984

--- a/QML/Assets/items/Inv_jewelry_ring_53naxxramas.png
+++ b/QML/Assets/items/Inv_jewelry_ring_53naxxramas.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b84b40fa2df95c47e61f6a8c44e80e396899d1a6d42e0414f2d36c7619f1969c
+size 5764

--- a/qml.qrc
+++ b/qml.qrc
@@ -1059,5 +1059,6 @@
         <file>QML/Assets/items/Inv_chest_plate09.png</file>
         <file>QML/Assets/items/Inv_pants_leather_05.png</file>
         <file>QML/Assets/items/Inv_sword_13.png</file>
+        <file>QML/Assets/items/Inv_jewelry_ring_53naxxramas.png</file>
     </qresource>
 </RCC>

--- a/qml.qrc
+++ b/qml.qrc
@@ -1060,5 +1060,6 @@
         <file>QML/Assets/items/Inv_pants_leather_05.png</file>
         <file>QML/Assets/items/Inv_sword_13.png</file>
         <file>QML/Assets/items/Inv_jewelry_ring_53naxxramas.png</file>
+        <file>QML/Assets/items/Inv_gauntlets_18.png</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Add missing assets:

 - Band of the Inevitable: `Inv_jewelry_ring_53naxxramas.png`
 - Gloves of Earthen Power: `Inv_gauntlets_18.png`

I created this bug in #261. Will make sure to test the icons in the future.

EDIT: I've confirmed images are working for all items added in #261 with this PR. 