### PR TITLE
Druid fixes

### DIFF
--- a/Character/Character.cpp
+++ b/Character/Character.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "Character.h"
 
 #include "AutoShot.h"
@@ -213,6 +215,11 @@ bool Character::action_ready() const {
     // Allow some rounding errors (this could effectively speed up gcd by 1/10000ths of a second).
     double delta = next_gcd - engine->get_current_priority();
     return delta < 0.0001 && !spells->cast_in_progress();
+}
+
+double Character::time_until_action_ready() const {
+    double delta = next_gcd - engine->get_current_priority();
+    return (delta > 0) ? delta : 0;
 }
 
 void Character::melee_mh_white_hit_effect() {

--- a/Character/Character.h
+++ b/Character/Character.h
@@ -90,6 +90,7 @@ public:
     bool on_global_cooldown() const;
     void start_trinket_cooldown(const double);
     bool on_trinket_cooldown() const;
+    double time_until_action_ready() const;
 
     virtual void melee_mh_white_hit_effect();
     virtual void melee_mh_white_critical_effect();

--- a/Class/Druid/Druid.cpp
+++ b/Class/Druid/Druid.cpp
@@ -115,10 +115,6 @@ double Druid::global_cooldown() const {
     return 1.5;
 }
 
-double Druid::form_cooldown() const {
-    return 1.0;
-}
-
 void Druid::set_clvl(const unsigned clvl_) {
     this->clvl = clvl_;
     this->rage_conversion_value = 0.0091107836 * std::pow(clvl, 2) + 3.225598133 * clvl + 4.2652911;
@@ -200,10 +196,6 @@ DruidForm Druid::get_current_form() const {
     return this->current_form;
 }
 
-bool Druid::on_form_cooldown() const {
-    return engine->get_current_priority() < this->next_form_cd;
-}
-
 void Druid::cancel_form() {
     switch (this->current_form) {
     case DruidForm::Caster:
@@ -229,8 +221,7 @@ void Druid::switch_to_form(const DruidForm new_form) {
     if (new_form == DruidForm::Caster)
         return cancel_form();
 
-    if (on_form_cooldown())
-        return;
+    if (on_global_cooldown()) return;
 
     cancel_form();
     druid_spells->get_caster_form()->buff->cancel_buff();
@@ -251,10 +242,8 @@ void Druid::switch_to_form(const DruidForm new_form) {
         check(false, "Unhandled form in Druid::switch_to_form()");
     }
 
-    this->next_form_cd = engine->get_current_priority() + form_cooldown();
-
-    if ((engine->get_current_priority() + 0.5) > this->next_gcd) {
-        this->next_gcd = engine->get_current_priority() + 0.5;
+    if ((engine->get_current_priority() + 1.5) > this->next_gcd) {
+        this->next_gcd = engine->get_current_priority() + 1.5;
         engine->add_event(new PlayerAction(spells, next_gcd));
     }
 }
@@ -320,7 +309,6 @@ void Druid::reset_resource() {
 
 void Druid::reset_class_specific() {
     cancel_form();
-    this->next_form_cd = -10.0;
     this->combo_points = 0;
     this->stealthed = false;
 }

--- a/Class/Druid/Druid.h
+++ b/Class/Druid/Druid.h
@@ -24,7 +24,6 @@ public:
     double get_int_needed_for_one_percent_spell_crit() const override;
     double get_mp5_from_spirit() const override;
     double global_cooldown() const override;
-    double form_cooldown() const;
     void set_clvl(const unsigned clvl) override;
 
     unsigned get_melee_ap_per_strength() const override;
@@ -48,7 +47,6 @@ public:
     void spell_critical_effect(MagicSchool magic_school) override;
 
     DruidForm get_current_form() const;
-    bool on_form_cooldown() const;
     void cancel_form();
     void switch_to_form(const DruidForm new_form);
 
@@ -70,7 +68,6 @@ private:
     Rage* rage;
 
     DruidForm current_form {DruidForm::Caster};
-    double next_form_cd {-10.0};
     double rage_conversion_value;
     unsigned combo_points {0};
     bool stealthed {false};

--- a/Class/Druid/Spells/BearForm.cpp
+++ b/Class/Druid/Spells/BearForm.cpp
@@ -11,7 +11,7 @@ BearForm::BearForm(Druid* druid, Buff* bear_form) :
           "Assets/ability/Ability_racial_bearform.png",
           druid,
           new CooldownControl(druid, 0.0),
-          RestrictedByGcd::No,
+          RestrictedByGcd::Yes,
           ResourceType::Mana,
           100),
     TalentRequirer({
@@ -32,7 +32,7 @@ SpellStatus BearForm::is_ready_spell_specific() const {
     if (druid->get_current_form() == DruidForm::Bear)
         return SpellStatus::InBearForm;
 
-    return druid->on_form_cooldown() ? SpellStatus::OnFormCooldown : SpellStatus::Available;
+    return SpellStatus::Available;
 }
 
 void BearForm::spell_effect() {

--- a/Class/Druid/Spells/CatForm.cpp
+++ b/Class/Druid/Spells/CatForm.cpp
@@ -10,7 +10,7 @@
 #include "StatisticsResource.h"
 
 CatForm::CatForm(Druid* druid, Buff* cat_form) :
-    Spell("Cat Form", "Assets/ability/Ability_druid_catform.png", druid, new CooldownControl(druid, 0.0), RestrictedByGcd::No, ResourceType::Mana, 100),
+    Spell("Cat Form", "Assets/ability/Ability_druid_catform.png", druid, new CooldownControl(druid, 0.0), RestrictedByGcd::Yes, ResourceType::Mana, 100),
     TalentRequirer({
         new TalentRequirerInfo("Natural Shapeshifter", 3, DisabledAtZero::No),
         new TalentRequirerInfo("Sharpened Claws", 3, DisabledAtZero::No),
@@ -34,7 +34,7 @@ SpellStatus CatForm::is_ready_spell_specific() const {
     if (druid->get_current_form() == DruidForm::Cat)
         return SpellStatus::InCatForm;
 
-    return druid->on_form_cooldown() ? SpellStatus::OnFormCooldown : SpellStatus::Available;
+    return SpellStatus::Available;
 }
 
 void CatForm::spell_effect() {

--- a/Class/Druid/Spells/MoonkinForm.cpp
+++ b/Class/Druid/Spells/MoonkinForm.cpp
@@ -12,7 +12,7 @@ MoonkinForm::MoonkinForm(Druid* druid, MoonkinFormBuff* buff) :
           "Assets/spell/Spell_nature_forceofnature.png",
           druid,
           new CooldownControl(druid, 0.0),
-          RestrictedByGcd::No,
+          RestrictedByGcd::Yes,
           ResourceType::Mana,
           100),
     TalentRequirer(
@@ -31,7 +31,7 @@ SpellStatus MoonkinForm::is_ready_spell_specific() const {
     if (druid->get_current_form() == DruidForm::Moonkin)
         return SpellStatus::InMoonkinForm;
 
-    return druid->on_form_cooldown() ? SpellStatus::OnFormCooldown : SpellStatus::Available;
+    return SpellStatus::Available;
 }
 
 void MoonkinForm::spell_effect() {

--- a/Class/Druid/Spells/TigersFury.cpp
+++ b/Class/Druid/Spells/TigersFury.cpp
@@ -16,7 +16,7 @@ TigersFury::TigersFury(Druid* pchar, DruidSpells* druid_spells, TigersFuryBuff* 
           "Assets/ability/Ability_mount_jungletiger.png",
           pchar,
           new CooldownControl(pchar, 1.0),
-          RestrictedByGcd::Yes,
+          RestrictedByGcd::No,
           ResourceType::Energy,
           30,
           spell_rank),

--- a/Rotation/Conditions/ConditionVariableBuiltin.cpp
+++ b/Rotation/Conditions/ConditionVariableBuiltin.cpp
@@ -1,6 +1,7 @@
 #include "ConditionVariableBuiltin.h"
 
 #include <cmath>
+#include <iostream>
 
 #include "AutoShot.h"
 #include "Character.h"
@@ -61,6 +62,10 @@ bool ConditionVariableBuiltin::condition_fulfilled() const {
 
         return false;
     }
+    case BuiltinVariables::TimeRemainingGCD:
+        //std::cout << "Time remaining GCD: " << pchar->time_until_action_ready() << std::endl;
+        return cmp_values(pchar->time_until_action_ready());
+
     default:
         check(false, "ConditionVariableBuiltin::condition_fulfilled reached end of switch");
         return false;
@@ -82,6 +87,8 @@ QString ConditionVariableBuiltin::condition_description() const {
         return QString("Melee Attack Power %1 %2").arg(comparator_as_string()).arg(QString::number(rhs_value, 'f', 0));
     if (builtin == BuiltinVariables::ComboPoints)
         return QString("Combo Points %1 %2").arg(comparator_as_string()).arg(QString::number(rhs_value, 'f', 0));
+    if (builtin == BuiltinVariables::TimeRemainingGCD)
+        return QString("Time Remaining GCD %1 %2 seconds").arg(comparator_as_string()).arg(QString::number(rhs_value, 'f', 1));
 
     return "<builtin variable is missing condition description>";
 }
@@ -119,6 +126,8 @@ BuiltinVariables ConditionVariableBuiltin::get_builtin_variable(const QString& v
         return BuiltinVariables::MeleeAP;
     if (var_name == "combo_points")
         return BuiltinVariables::ComboPoints;
+    if (var_name == "time_remaining_gcd")
+        return BuiltinVariables::TimeRemainingGCD;
 
     return BuiltinVariables::Undefined;
 }

--- a/Rotation/Conditions/ConditionVariableBuiltin.h
+++ b/Rotation/Conditions/ConditionVariableBuiltin.h
@@ -14,7 +14,8 @@ enum BuiltinVariables
     SwingTimer,
     AutoShotTimer,
     MeleeAP,
-    ComboPoints
+    ComboPoints,
+    TimeRemainingGCD
 };
 
 class ConditionVariableBuiltin : public Condition {

--- a/Rotation/Rotations/Druid/FeralPowershifting.xml
+++ b/Rotation/Rotations/Druid/FeralPowershifting.xml
@@ -34,7 +34,8 @@
     <cast_if name="Shred"/>
 
     <cast_if name="Caster Form">
-        resource "Energy" leq 20
+        resource "Energy" leq 47
         and resource "Mana" geq 400
+		and variable "time_remaining_gcd" leq 0
     </cast_if>
 </rotation>

--- a/Test/Druid/Spells/TestCatForm.cpp
+++ b/Test/Druid/Spells/TestCatForm.cpp
@@ -35,6 +35,10 @@ void TestCatForm::test_all() {
     tear_down();
 
     set_up();
+    test_how_spell_observes_global_cooldown();
+    tear_down();
+
+    set_up();
     test_hit_dmg();
     tear_down();
 
@@ -75,7 +79,19 @@ void TestCatForm::test_whether_spell_causes_global_cooldown() {
     assert(!druid->action_ready());
 }
 
-void TestCatForm::test_how_spell_observes_global_cooldown() {}
+void TestCatForm::test_how_spell_observes_global_cooldown() {
+    assert(druid->action_ready());
+
+    when_cat_form_is_performed();
+    assert(!druid->action_ready());
+
+    druid->cancel_form();
+    assert(!druid->action_ready());
+
+    when_cat_form_is_performed();
+    assert(!druid->action_ready());
+    assert(druid->get_current_form() == DruidForm::Caster);
+}
 
 void TestCatForm::test_is_ready_conditions() {
     assert(cat_form()->get_spell_status() == SpellStatus::Available);

--- a/Test/Druid/Spells/TestFerociousBite.cpp
+++ b/Test/Druid/Spells/TestFerociousBite.cpp
@@ -46,7 +46,7 @@ void TestFerociousBite::test_spell_cooldown() {
 void TestFerociousBite::test_whether_spell_causes_global_cooldown() {
     given_druid_in_cat_form();
     given_druid_has_combo_points(1);
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     assert(druid->action_ready());
 
     when_ferocious_bite_is_performed();
@@ -57,7 +57,7 @@ void TestFerociousBite::test_whether_spell_causes_global_cooldown() {
 void TestFerociousBite::test_how_spell_observes_global_cooldown() {
     given_druid_in_cat_form();
     given_druid_has_combo_points(1);
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     assert(druid->action_ready());
 
     when_shred_is_performed();
@@ -70,7 +70,7 @@ void TestFerociousBite::test_resource_cost() {
     given_druid_has_combo_points(1);
     given_a_guaranteed_melee_ability_hit();
     assert(druid->get_resource_level(ResourceType::Energy) == 100);
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_ferocious_bite_is_performed();
 
@@ -81,7 +81,7 @@ void TestFerociousBite::test_is_ready_conditions() {
     assert(ferocious_bite()->get_spell_status() == SpellStatus::InCasterForm);
 
     given_druid_in_cat_form();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     assert(ferocious_bite()->get_spell_status() == SpellStatus::InsufficientComboPoints);
 
@@ -95,7 +95,7 @@ void TestFerociousBite::test_hit_dmg() {
     given_druid_in_cat_form();
     given_1000_melee_ap();
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_combo_points(5);
 
     when_ferocious_bite_is_performed();
@@ -111,7 +111,7 @@ void TestFerociousBite::test_crit_dmg() {
     given_druid_in_cat_form();
     given_1000_melee_ap();
     given_a_guaranteed_melee_ability_crit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_combo_points(5);
 
     when_ferocious_bite_is_performed();
@@ -125,7 +125,7 @@ void TestFerociousBite::test_ferocious_bite_spends_combo_points() {
     given_druid_in_cat_form();
     given_druid_has_combo_points(5);
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_ferocious_bite_is_performed();
 
@@ -139,7 +139,7 @@ void TestFerociousBite::test_hit_dmg_feral_aggression_5_of_5() {
     given_druid_in_cat_form();
     given_1000_melee_ap();
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_combo_points(5);
 
     when_ferocious_bite_is_performed();
@@ -156,7 +156,7 @@ void TestFerociousBite::test_crit_dmg_feral_aggression_5_of_5() {
     given_druid_in_cat_form();
     given_1000_melee_ap();
     given_a_guaranteed_melee_ability_crit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_combo_points(5);
 
     when_ferocious_bite_is_performed();

--- a/Test/Druid/Spells/TestMaul.cpp
+++ b/Test/Druid/Spells/TestMaul.cpp
@@ -57,8 +57,9 @@ void TestMaul::test_spell_cooldown() {
 
 void TestMaul::test_whether_spell_causes_global_cooldown() {
     given_druid_in_bear_form();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_rage(100);
+
     assert(druid->action_ready());
 
     when_maul_is_performed();
@@ -72,7 +73,6 @@ void TestMaul::test_resource_cost() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
     given_druid_has_rage(100);
-    given_engine_priority_at(0.51);
 
     when_maul_is_performed();
 
@@ -83,7 +83,6 @@ void TestMaul::test_is_ready_conditions() {
     assert(maul()->get_spell_status() == SpellStatus::InsufficientResources);
 
     given_druid_in_bear_form();
-    given_engine_priority_at(0.51);
 
     assert(maul()->get_spell_status() == SpellStatus::InsufficientResources);
 
@@ -97,7 +96,6 @@ void TestMaul::test_resource_cost_1_of_5_ferocity() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
     given_druid_has_rage(100);
-    given_engine_priority_at(0.51);
 
     when_maul_is_performed();
 
@@ -109,7 +107,6 @@ void TestMaul::test_resource_cost_2_of_5_ferocity() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
     given_druid_has_rage(100);
-    given_engine_priority_at(0.51);
 
     when_maul_is_performed();
 
@@ -121,7 +118,6 @@ void TestMaul::test_resource_cost_3_of_5_ferocity() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
     given_druid_has_rage(100);
-    given_engine_priority_at(0.51);
 
     when_maul_is_performed();
 
@@ -133,7 +129,6 @@ void TestMaul::test_resource_cost_4_of_5_ferocity() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
     given_druid_has_rage(100);
-    given_engine_priority_at(0.51);
 
     when_maul_is_performed();
 
@@ -145,7 +140,6 @@ void TestMaul::test_resource_cost_5_of_5_ferocity() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
     given_druid_has_rage(100);
-    given_engine_priority_at(0.51);
 
     when_maul_is_performed();
 
@@ -160,7 +154,6 @@ void TestMaul::test_hit_dmg_1_of_2_savage_fury() {
     given_1000_melee_ap();
     given_druid_has_rage(100);
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
 
     when_maul_is_performed();
 
@@ -177,7 +170,6 @@ void TestMaul::test_hit_dmg_2_of_2_savage_fury() {
     given_1000_melee_ap();
     given_druid_has_rage(100);
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
 
     when_maul_is_performed();
 
@@ -193,7 +185,6 @@ void TestMaul::test_hit_dmg() {
     given_1000_melee_ap();
     given_druid_has_rage(100);
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
 
     when_maul_is_performed();
 
@@ -209,7 +200,6 @@ void TestMaul::test_hit_threat() {
     given_1000_melee_ap();
     given_druid_has_rage(100);
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
 
     when_maul_is_performed();
 
@@ -228,7 +218,6 @@ void TestMaul::test_crit_dmg() {
     given_1000_melee_ap();
     given_druid_has_rage(100);
     given_a_guaranteed_melee_ability_crit();
-    given_engine_priority_at(0.51);
 
     when_maul_is_performed();
 

--- a/Test/Druid/Spells/TestShred.cpp
+++ b/Test/Druid/Spells/TestShred.cpp
@@ -56,12 +56,16 @@ void TestShred::test_spell_cooldown() {
 
 void TestShred::test_whether_spell_causes_global_cooldown() {
     given_druid_in_cat_form();
-    given_engine_priority_at(0.51);
-    assert(druid->action_ready());
-
-    when_shred_is_performed();
-
+    given_engine_priority_at(1.01);
     assert(!druid->action_ready());
+
+    given_engine_priority_at(1.51);
+    assert(druid->action_ready());
+    when_shred_is_performed();
+    assert(!druid->action_ready());
+
+    given_engine_priority_at(2.52);
+    assert(druid->action_ready());
 }
 
 void TestShred::test_how_spell_observes_global_cooldown() {}
@@ -70,7 +74,7 @@ void TestShred::test_resource_cost() {
     given_druid_in_cat_form();
     given_a_guaranteed_melee_ability_hit();
     assert(druid->get_resource_level(ResourceType::Energy) == 100);
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_shred_is_performed();
 
@@ -81,7 +85,7 @@ void TestShred::test_is_ready_conditions() {
     assert(shred()->get_spell_status() == SpellStatus::InCasterForm);
 
     given_druid_in_cat_form();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     assert(shred()->get_spell_status() == SpellStatus::Available);
 }
@@ -91,7 +95,7 @@ void TestShred::test_resource_cost_1_of_2_improved_shred() {
     given_druid_in_cat_form();
     given_a_guaranteed_melee_ability_hit();
     assert(druid->get_resource_level(ResourceType::Energy) == 100);
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_shred_is_performed();
 
@@ -103,7 +107,7 @@ void TestShred::test_resource_cost_2_of_2_improved_shred() {
     given_druid_in_cat_form();
     given_a_guaranteed_melee_ability_hit();
     assert(druid->get_resource_level(ResourceType::Energy) == 100);
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_shred_is_performed();
 
@@ -116,7 +120,7 @@ void TestShred::test_hit_dmg() {
     given_druid_in_cat_form();
     given_1000_melee_ap();
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_shred_is_performed();
 
@@ -131,7 +135,7 @@ void TestShred::test_crit_dmg() {
     given_druid_in_cat_form();
     given_1000_melee_ap();
     given_a_guaranteed_melee_ability_crit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_shred_is_performed();
 
@@ -143,7 +147,7 @@ void TestShred::test_crit_dmg() {
 void TestShred::test_shred_hit_with_0_of_2_blood_frenzy_awards_1_combo_point() {
     given_druid_in_cat_form();
     given_a_guaranteed_melee_ability_crit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     assert(druid->get_combo_points() == 0);
 
     when_shred_is_performed();
@@ -154,7 +158,7 @@ void TestShred::test_shred_hit_with_0_of_2_blood_frenzy_awards_1_combo_point() {
 void TestShred::test_shred_crit_with_0_of_2_blood_frenzy_awards_1_combo_point() {
     given_druid_in_cat_form();
     given_a_guaranteed_melee_ability_crit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     assert(druid->get_combo_points() == 0);
 
     when_shred_is_performed();
@@ -167,7 +171,7 @@ void TestShred::test_shred_hit_with_2_of_2_blood_frenzy_awards_1_combo_point() {
     pchar->prepare_set_of_combat_iterations();
     given_druid_in_cat_form();
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     assert(druid->get_combo_points() == 0);
 
     when_shred_is_performed();
@@ -180,7 +184,7 @@ void TestShred::test_shred_crit_with_2_of_2_blood_frenzy_awards_2_combo_points()
     pchar->prepare_set_of_combat_iterations();
     given_druid_in_cat_form();
     given_a_guaranteed_melee_ability_crit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     assert(druid->get_combo_points() == 0);
 
     when_shred_is_performed();

--- a/Test/Druid/Spells/TestSwipe.cpp
+++ b/Test/Druid/Spells/TestSwipe.cpp
@@ -68,7 +68,7 @@ void TestSwipe::test_spell_cooldown() {
 
 void TestSwipe::test_whether_spell_causes_global_cooldown() {
     given_druid_in_bear_form();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_rage(100);
     assert(druid->action_ready());
 
@@ -83,7 +83,7 @@ void TestSwipe::test_resource_cost() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
     given_druid_has_rage(100);
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_swipe_is_performed();
 
@@ -94,7 +94,7 @@ void TestSwipe::test_is_ready_conditions() {
     assert(swipe()->get_spell_status() == SpellStatus::InsufficientResources);
 
     given_druid_in_bear_form();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     assert(swipe()->get_spell_status() == SpellStatus::InsufficientResources);
 
@@ -108,7 +108,7 @@ void TestSwipe::test_resource_cost_1_of_5_ferocity() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
     given_druid_has_rage(100);
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_swipe_is_performed();
 
@@ -120,7 +120,7 @@ void TestSwipe::test_resource_cost_2_of_5_ferocity() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
     given_druid_has_rage(100);
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_swipe_is_performed();
 
@@ -132,7 +132,7 @@ void TestSwipe::test_resource_cost_3_of_5_ferocity() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
     given_druid_has_rage(100);
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_swipe_is_performed();
 
@@ -144,7 +144,7 @@ void TestSwipe::test_resource_cost_4_of_5_ferocity() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
     given_druid_has_rage(100);
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_swipe_is_performed();
 
@@ -156,7 +156,7 @@ void TestSwipe::test_resource_cost_5_of_5_ferocity() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
     given_druid_has_rage(100);
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
 
     when_swipe_is_performed();
 
@@ -169,7 +169,7 @@ void TestSwipe::test_hit_dmg_1_of_2_savage_fury() {
     given_druid_in_bear_form();
     given_1000_melee_ap();
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_rage(100);
 
     when_swipe_is_performed();
@@ -184,7 +184,7 @@ void TestSwipe::test_hit_dmg_2_of_2_savage_fury() {
     given_druid_in_bear_form();
     given_1000_melee_ap();
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_rage(100);
 
     when_swipe_is_performed();
@@ -199,7 +199,7 @@ void TestSwipe::test_hit_dmg() {
     given_druid_in_bear_form();
     given_1000_melee_ap();
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_rage(100);
 
     when_swipe_is_performed();
@@ -214,7 +214,7 @@ void TestSwipe::test_crit_dmg() {
     given_druid_in_bear_form();
     given_1000_melee_ap();
     given_a_guaranteed_melee_ability_crit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_rage(100);
 
     when_swipe_is_performed();
@@ -226,7 +226,7 @@ void TestSwipe::test_crit_dmg() {
 void TestSwipe::test_swipe_hit_with_0_of_2_primal_fury_awards_0_rage() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_crit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_rage(100);
 
     when_swipe_is_performed();
@@ -237,7 +237,7 @@ void TestSwipe::test_swipe_hit_with_0_of_2_primal_fury_awards_0_rage() {
 void TestSwipe::test_swipe_crit_with_0_of_2_primal_fury_awards_0_rage() {
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_crit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_rage(100);
 
     when_swipe_is_performed();
@@ -250,7 +250,7 @@ void TestSwipe::test_swipe_hit_with_2_of_2_primal_fury_awards_0_rage() {
     pchar->prepare_set_of_combat_iterations();
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_hit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_rage(100);
 
     when_swipe_is_performed();
@@ -263,7 +263,7 @@ void TestSwipe::test_swipe_crit_with_2_of_2_primal_fury_awards_5_rage() {
     pchar->prepare_set_of_combat_iterations();
     given_druid_in_bear_form();
     given_a_guaranteed_melee_ability_crit();
-    given_engine_priority_at(0.51);
+    given_engine_priority_at(1.51);
     given_druid_has_rage(100);
 
     when_swipe_is_performed();


### PR DESCRIPTION
- Shapeshifting cooldowns are on GCD (cancelform is not)
- Tiger's Fury is off GCD (TODO: Still missing its own CD but it's useless to cast it more than once within a second)
- Powershifting rotation does not leave cat form when GCD is not ready (prevents meleeing in caster form)
- New BuiltinVariable "time_remaining_gcd" used to prevent shapeshifting in rotations when powershifting is not possible (action not ready)

See #219 