### PR TITLE
Remove 'Could not find buff for' Warning

### DIFF
--- a/Rotation/Rotation.cpp
+++ b/Rotation/Rotation.cpp
@@ -132,7 +132,6 @@ bool Rotation::add_conditionals(RotationExecutor* executor) {
         case ConditionType::BuffStacksCondition: {
             Buff* buff = pchar->get_spells()->get_buff_by_name(sentence->type_value);
             if (buff == nullptr) {
-                qDebug() << "could not find buff for condition:" << sentence->type_value;
                 return false;
             }
             condition = new ConditionBuffStacks(buff, sentence->mathematical_symbol, sentence->compared_value.toInt());
@@ -141,7 +140,6 @@ bool Rotation::add_conditionals(RotationExecutor* executor) {
         case ConditionType::BuffDurationCondition: {
             Buff* buff = pchar->get_spells()->get_buff_by_name(sentence->type_value);
             if (buff == nullptr) {
-                qDebug() << "could not find buff for condition:" << sentence->type_value;
                 return false;
             }
             condition = new ConditionBuffDuration(buff, sentence->mathematical_symbol, sentence->compared_value.toDouble());


### PR DESCRIPTION
This doesn't really make sense to complain about. This warning will
show up when, for example, a rotation attempts to use an ability with a
buff but the player didn't choose that talent. This is perfectly fine
and the rotation should just move on. But this spams the log with this
error message.