### PR TITLE
Add a attacking_from_behind setup and have target parry use it

### DIFF
--- a/Character/Character.cpp
+++ b/Character/Character.cpp
@@ -1,6 +1,6 @@
-#include <algorithm>
-
 #include "Character.h"
+
+#include <algorithm>
 
 #include "AutoShot.h"
 #include "CharacterSpells.h"
@@ -113,6 +113,18 @@ int Character::get_party() const {
 
 int Character::get_party_member() const {
     return this->party_member;
+}
+
+bool Character::is_attacking_from_behind() const {
+    return !char_is_tanking;
+}
+
+bool Character::is_tanking() const {
+    return char_is_tanking;
+}
+
+void Character::set_is_tanking(bool new_value) {
+    this->char_is_tanking = new_value;
 }
 
 bool Character::is_dual_wielding() const {

--- a/Character/Character.h
+++ b/Character/Character.h
@@ -83,6 +83,10 @@ public:
 
     void add_player_reaction_event();
 
+    bool is_attacking_from_behind() const;
+    void set_is_tanking(bool new_value);
+    bool is_tanking() const;
+
     virtual bool is_dual_wielding() const;
     bool action_ready() const;
     void start_global_cooldown();
@@ -182,6 +186,8 @@ protected:
     double next_trinket_cd;
     int party;
     int party_member;
+
+    bool char_is_tanking = false;
 
     virtual void initialize_talents() = 0;
 

--- a/Character/CharacterEncoder.cpp
+++ b/Character/CharacterEncoder.cpp
@@ -70,6 +70,8 @@ QString CharacterEncoder::get_current_setup_string() {
 
     key_val("RULESET", QString::number(pchar->get_sim_settings()->get_ruleset()));
 
+    key_val("TANKING", QString::number(pchar->is_tanking()));
+
     return pchar_str;
 }
 

--- a/Character/CharacterLoader.cpp
+++ b/Character/CharacterLoader.cpp
@@ -80,6 +80,7 @@ void CharacterLoader::initialize_existing(Character* pchar) {
     select_rotation(decoder, pchar);
     apply_enchants(decoder, pchar);
     apply_ruleset(decoder, pchar);
+    apply_tanking(decoder, pchar);
 
     success = true;
 }
@@ -358,6 +359,11 @@ void CharacterLoader::apply_enchants(CharacterDecoder& decoder, Character* pchar
 
 void CharacterLoader::apply_ruleset(CharacterDecoder& decoder, Character* pchar) {
     pchar->get_sim_settings()->use_ruleset(static_cast<Ruleset>(decoder.get_value("RULESET").toInt()), pchar);
+}
+
+void CharacterLoader::apply_tanking(CharacterDecoder& decoder, Character* pchar) {
+    auto is_tanking = decoder.get_value("TANKING").toInt();
+    pchar->set_is_tanking(is_tanking);
 }
 
 void CharacterLoader::setup_target(CharacterDecoder& decoder) {

--- a/Character/CharacterLoader.h
+++ b/Character/CharacterLoader.h
@@ -50,6 +50,7 @@ private:
     void apply_external_debuffs(CharacterDecoder& decoder, Character* pchar);
     void apply_enchants(CharacterDecoder& decoder, Character* pchar);
     void apply_ruleset(CharacterDecoder& decoder, Character* pchar);
+    void apply_tanking(CharacterDecoder& decoder, Character* pchar);
     void setup_target(CharacterDecoder& decoder);
     void select_rotation(CharacterDecoder& decoder, Character* pchar);
     EnchantName::Name get_enum_val(const QString& enum_val_as_string);

--- a/CombatRoll/CombatRoll.h
+++ b/CombatRoll/CombatRoll.h
@@ -35,8 +35,8 @@ public:
     int get_pet_hit_result(const unsigned wpn_skill, const unsigned crit_mod);
     int get_pet_ability_result(const unsigned wpn_skill, const unsigned crit_mod);
 
-    MeleeWhiteHitTable* get_melee_white_table(const unsigned wpn_skill);
-    MeleeSpecialTable* get_melee_special_table(const unsigned wpn_skill);
+    MeleeWhiteHitTable* get_melee_white_table(const unsigned wpn_skill, bool is_attacking_from_behind = true);
+    MeleeSpecialTable* get_melee_special_table(const unsigned wpn_skill, bool is_attacking_from_behind = true);
     RangedWhiteHitTable* get_ranged_white_table(const unsigned wpn_skill);
     MagicAttackTable* get_magic_attack_table(const MagicSchool);
     MeleeWhiteHitTable* get_pet_white_table(const unsigned wpn_skill);
@@ -64,8 +64,8 @@ private:
     Random* random;
     Random* glance_roll;
 
-    QMap<unsigned, MeleeWhiteHitTable*> melee_white_tables;
-    QMap<unsigned, MeleeSpecialTable*> melee_special_tables;
+    QMap<QPair<unsigned, bool>, MeleeWhiteHitTable*> melee_white_tables;
+    QMap<QPair<unsigned, bool>, MeleeSpecialTable*> melee_special_tables;
     QMap<unsigned, RangedWhiteHitTable*> ranged_white_tables;
     QMap<MagicSchool, MagicAttackTable*> magic_attack_tables;
     QMap<unsigned, MeleeWhiteHitTable*> pet_white_tables;

--- a/Mechanics/Mechanics.cpp
+++ b/Mechanics/Mechanics.cpp
@@ -43,8 +43,9 @@ double Mechanics::get_dodge_chance(const unsigned wpn_skill) const {
     return std::max(0.0, 0.05 + defense_diff * 0.001);
 }
 
-double Mechanics::get_parry_chance(const unsigned) const {
-    return 0.0;
+double Mechanics::get_parry_chance(const unsigned wpn_skill) const {
+    const int defense_diff = static_cast<int>(target->get_defense()) - static_cast<int>(wpn_skill);
+    return std::max(0.0, 0.14 + defense_diff * 0.001);
 }
 
 double Mechanics::get_block_chance() const {


### PR DESCRIPTION
This is a simple setup that adds a `is_tanking` value to `Character`
which is then used by CombatRoll and Mechanics to correctly calculate
parry rates. Now we need a GUI toggle for `is_tanking`.