### PR TITLE
Fix restoring last toggled rotation from save file

### DIFF
--- a/Character/Character.cpp
+++ b/Character/Character.cpp
@@ -553,3 +553,11 @@ void Character::set_special_statistics() {
         cstats->decrease_stamina(1);
     }
 }
+
+QString const& Character::get_rotation_name() const {
+  return rotation_name;
+}
+
+void Character::set_rotation_name(QString name) {
+  this->rotation_name = std::move(name);
+}

--- a/Character/Character.h
+++ b/Character/Character.h
@@ -160,6 +160,9 @@ public:
     const QString class_name;
     const QString class_color;
 
+    QString const& get_rotation_name() const;
+    void set_rotation_name(QString name);
+
 protected:
     Race* race;
     Engine* engine;
@@ -177,6 +180,8 @@ protected:
     Resource* resource {nullptr};
     Pet* pet {nullptr};
     RaidControl* raid_control {nullptr};
+
+    QString rotation_name;
 
     QString player_name;
     QVector<QString> available_races;

--- a/Character/CharacterSpells.cpp
+++ b/Character/CharacterSpells.cpp
@@ -62,6 +62,7 @@ CharacterSpells::~CharacterSpells() {
 
 void CharacterSpells::set_rotation(Rotation* rotation) {
     this->rotation = rotation;
+    this->pchar->set_rotation_name(rotation->get_name());
     this->rotation->link_spells(pchar);
     set_attack_mode(this->rotation->get_attack_mode());
 }

--- a/GUI/ClassicSimControl.cpp
+++ b/GUI/ClassicSimControl.cpp
@@ -238,7 +238,10 @@ void ClassicSimControl::set_character(Character* pchar) {
     item_model->set_character(current_char);
     weapon_model->set_character(current_char);
     rotation_model->set_character(current_char);
-    selectInformationRotation(0);
+    if (auto index = rotation_model->get_index_of_rotation_named(pchar->get_rotation_name()))
+      selectInformationRotation(*index);
+    else
+      selectInformationRotation(0);
     rotation_model->select_rotation();
     character_encoder->set_character(current_char);
     buff_model->set_character(current_char);

--- a/GUI/Models/RotationModel.cpp
+++ b/GUI/Models/RotationModel.cpp
@@ -1,5 +1,7 @@
 #include "RotationModel.h"
 
+#include <optional>
+
 #include "Character.h"
 #include "CharacterSpells.h"
 #include "Rotation.h"
@@ -19,6 +21,7 @@ void RotationModel::set_character(Character* pchar) {
     this->pchar = pchar;
     information_index = -1;
     addRotations();
+
     select_rotation();
 }
 
@@ -38,8 +41,6 @@ void RotationModel::addRotations() {
 
         beginInsertRows(QModelIndex(), rowCount(), rowCount());
         rotations[rotation->get_class()].append(rotation);
-
-        information_index = 0;
 
         endInsertRows();
     }
@@ -121,4 +122,13 @@ void RotationModel::clear_rotations() {
             delete rotation;
 
     rotations.clear();
+}
+
+std::optional<int> RotationModel::get_index_of_rotation_named(QString const& name) const {
+    for (int i = 0; i < rotations[pchar->class_name].size(); ++i) {
+        if (rotations[pchar->class_name][i]->get_name() == name)
+            return i;
+    }
+
+    return std::nullopt;
 }

--- a/GUI/Models/RotationModel.h
+++ b/GUI/Models/RotationModel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <QAbstractListModel>
 #include <QMap>
 #include <QStringList>
@@ -27,6 +29,8 @@ public:
 
     void select_rotation();
     bool set_information_index(const int);
+
+    std::optional<int> get_index_of_rotation_named(QString const& name) const;
 
     QString get_rotation_information_name() const;
     QString get_rotation_information_description() const;


### PR DESCRIPTION
Rotation is handled a bit weird here. We have 3 different toggleable
setups for talents, equipment and buffs. We save the rotation
information in the same fashion as the above trio, but it doens't realy
make sense to apply the rotation necessarily to any of the above three
things. So it lives separate. But adding three buttons to the GUI to
track rotations would be even clumsier than we currently have it.

So instead just save the last selected rotation to be loaded on the next
launch.

Also, this implementation is also pretty weird. The
`ClassicSimControl::set_character` method wipes the rotation database
each time it is called and rebuilds it from the rotation XML files. It
does this because the same `RotationModel` is used for each class and
thus needs to be reset while switching.

So this creates a few problems.
First, toggling from class A -> class B causes class A's rotation to be
invalid since the rotation gets `delete`ed.
Second, we don't know what the previous rotation was in the first place
in order to reselect it.

Thus, add a `QString` property for the current rotation attached to the
`Character` that will need to be updated accordingly.

A much nicer and harder future refactor would be to overhaul the
rotation system to remove this dance and have the `Character` store the
rotation database which is then loaned to the model and is thus
preserved between class switches.