### PR TITLE
Add Parry for the GUI

### DIFF
--- a/GUI/ClassicSimControl.cpp
+++ b/GUI/ClassicSimControl.cpp
@@ -935,6 +935,16 @@ void ClassicSimControl::runQuickSim() {
     emit simProgressChanged();
 }
 
+void ClassicSimControl::toggleTank() {
+    current_char->set_is_tanking(!current_char->is_tanking());
+
+    emit tankingChanged();
+}
+
+bool ClassicSimControl::get_is_tanking() const {
+    return current_char->is_tanking();
+}
+
 void ClassicSimControl::runFullSim() {
     if (sim_in_progress)
         return;
@@ -975,7 +985,8 @@ void ClassicSimControl::compile_thread_results() {
     rotation_executor_list_model->update_statistics();
     damage_meters_model->update_statistics();
     last_engine_handled_events_per_second = engine_breakdown_model->events_handled_per_second();
-    update_displayed_dps_value(number_cruncher->get_personal_dps(SimOption::Name::NoScale), number_cruncher->get_personal_tps(SimOption::Name::NoScale));
+    update_displayed_dps_value(number_cruncher->get_personal_dps(SimOption::Name::NoScale),
+                               number_cruncher->get_personal_tps(SimOption::Name::NoScale));
     update_displayed_raid_dps_value(number_cruncher->get_raid_dps());
     dps_distribution = number_cruncher->get_dps_distribution();
     number_cruncher->reset();
@@ -1993,10 +2004,10 @@ QVariantList ClassicSimControl::get_tooltip_from_item(Item* item) {
     else if (slot == "MH")
         set_weapon_tooltip(item, slot, "Main Hand", dmg_range, weapon_speed, dps);
     else if (slot == "OH")
-      if (item->get_item_type() != WeaponTypes::SHIELD)
-        set_weapon_tooltip(item, slot, "Offhand", dmg_range, weapon_speed, dps);
-      else
-        slot = "Offhand";
+        if (item->get_item_type() != WeaponTypes::SHIELD)
+            set_weapon_tooltip(item, slot, "Offhand", dmg_range, weapon_speed, dps);
+        else
+            slot = "Offhand";
     else if (slot == "2H")
         set_weapon_tooltip(item, slot, "Two-hand", dmg_range, weapon_speed, dps);
     else if (slot == "RANGED") {

--- a/GUI/ClassicSimControl.h
+++ b/GUI/ClassicSimControl.h
@@ -118,6 +118,10 @@ public:
     QString get_formatted_talent_allocation() const;
     /* End of Talents */
 
+    Q_INVOKABLE void toggleTank();
+    Q_PROPERTY(bool isTanking READ get_is_tanking NOTIFY tankingChanged)
+    bool get_is_tanking() const;
+
     /* Stats */
     Q_PROPERTY(unsigned strength READ get_strength NOTIFY statsChanged)
     Q_PROPERTY(unsigned agility READ get_agility NOTIFY statsChanged)
@@ -330,6 +334,7 @@ public:
     /* End of GUI initialization */
 
 signals:
+    void tankingChanged();
     void classChanged();
     void raceChanged();
     void factionChanged();

--- a/QML/main.qml
+++ b/QML/main.qml
@@ -510,6 +510,44 @@ Window {
         onButtonClicked: character.runFullSim()
     }
 
+    GradientButton {
+        id: toggleTankButton
+
+        anchors {
+            right: fullSimButton.left
+            rightMargin: 15
+            bottom: parent.bottom
+            bottomMargin: 15
+        }
+
+        height: 50
+        width: 200
+
+        Text {
+            font {
+                family: "Arial"
+                pointSize: 13
+                bold: true
+            }
+
+            function getTankingText() {
+                if (character.isTanking) {
+                    return "Disable Tanking"
+                } else {
+                    return "Enable Tanking"
+                }
+            }
+            text: getTankingText()
+
+            anchors.fill: parent
+
+            color: root.colorFaction
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+        onButtonClicked: character.toggleTank()
+    }
+
     PercentBar {
         visible: settings.simInProgress
         anchors.bottom: parent.bottom


### PR DESCRIPTION
Add an elegant and majestic toggle for the new tank flag. This, at the moment, only toggles whether or not the player will be getting paried.