### PR TITLE
Use mana pots better for mage rotations, only evocate if out of options

### DIFF
--- a/Rotation/Rotations/Mage/Arcane.xml
+++ b/Rotation/Rotations/Mage/Arcane.xml
@@ -24,13 +24,13 @@
         resource "Mana" greater 400
     </cast_if>
 
+    <cast_if name="Mana Potion"/>
+    <cast_if name="Demonic Rune"/>
+    <cast_if name="Night Dragon's Breath"/>
+
     <cast_if name="Arcane Missiles"/>
 
     <cast_if name="Evocation">
         resource "Mana" less 500
     </cast_if>
-
-    <cast_if name="Mana Potion"/>
-    <cast_if name="Demonic Rune"/>
-    <cast_if name="Night Dragon's Breath"/>
 </rotation>

--- a/Rotation/Rotations/Mage/Fire.xml
+++ b/Rotation/Rotations/Mage/Fire.xml
@@ -38,16 +38,15 @@
         and resource "Mana" greater 400
     </cast_if>
 
-    <cast_if name="Evocation">
-        resource "Mana" less 400
-    </cast_if>
+    <cast_if name="Mana Potion"/>
+    <cast_if name="Demonic Rune"/>
+    <cast_if name="Night Dragon's Breath"/>
 
     <cast_if name="Fireball">
         buff_stacks "Fire Vulnerability" eq 5
     </cast_if>
 
-
-    <cast_if name="Mana Potion"/>
-    <cast_if name="Demonic Rune"/>
-    <cast_if name="Night Dragon's Breath"/>
+    <cast_if name="Evocation">
+        resource "Mana" less 400
+    </cast_if>
 </rotation>

--- a/Rotation/Rotations/Mage/Frost.xml
+++ b/Rotation/Rotations/Mage/Frost.xml
@@ -24,13 +24,13 @@
         resource "Mana" greater 400
     </cast_if>
 
+    <cast_if name="Mana Potion"/>
+    <cast_if name="Demonic Rune"/>
+    <cast_if name="Night Dragon's Breath"/>
+
     <cast_if name="Frostbolt"/>
 
     <cast_if name="Evocation">
         resource "Mana" less 400
     </cast_if>
-
-    <cast_if name="Mana Potion"/>
-    <cast_if name="Demonic Rune"/>
-    <cast_if name="Night Dragon's Breath"/>
 </rotation>


### PR DESCRIPTION
Mage rotations were not optimal when it comes to using mana pots and evocation at the right time. Mana pots were only used when out of mana already. Now they are used whenever enough mana is used so that refilling would not go above 100% mana. This means we can often use more mana pots in a fight.

Also evocation is now used only when no mana pots/runes are available and the main damage spell failed because of mana issues.

I tested these changes and in short and long fights this rotation always yields higher DPS than the old rotation.

We might want to check other caster classes for this problem as well!